### PR TITLE
feat: Modern LLM Support via litellm

### DIFF
--- a/fix_test.py
+++ b/fix_test.py
@@ -1,0 +1,9 @@
+import traceback
+import os
+import streamlit as st
+from langchain_community.chat_models import ChatLiteLLM
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain, SequentialChain
+from langchain.memory import ConversationBufferMemory
+
+print("Success")

--- a/libs/openai_langchain.py
+++ b/libs/openai_langchain.py
@@ -1,7 +1,7 @@
 import traceback
 import os
 import streamlit as st
-from langchain.chat_models import ChatLiteLLM
+from langchain_community.chat_models import ChatLiteLLM
 from langchain.prompts import PromptTemplate
 from langchain.chains import LLMChain, SequentialChain
 from langchain.memory import ConversationBufferMemory
@@ -33,7 +33,7 @@ class OpenAILangChain:
             os.environ["OPENAI_API_KEY"] = api_key
         
         # Create a LiteLLM model
-        self.lite_llm = ChatLiteLLM(model=model, temperature=temprature, max_tokens=max_tokens, openai_api_key=api_key)
+        self.lite_llm = ChatLiteLLM(model=model, temperature=temprature, max_tokens=max_tokens, openai_api_key=api_key, api_key=api_key)
         
         if st.session_state.proxy_api:
             self.lite_llm.api_base = st.session_state.proxy_api

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ google-auth
 google-auth-oauthlib
 google-cloud-aiplatform
 langchain
+langchain-community
+litellm
 openai
 python-dotenv
 vertexai

--- a/script.py
+++ b/script.py
@@ -93,8 +93,7 @@ def main():
             with st.expander("Open AI Settings"):
                 try:
                     # Settings for Open AI model.
-                    model_options_openai = ["gpt-4", "gpt-4-0613", "gpt-4-32k", "gpt-4-32k-0613", "gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-3.5-turbo-0613", "gpt-3.5-turbo-16k-0613", "gpt-3.5-turbo-0301", "text-davinci-003"]
-                    st.session_state["openai"]["model_name"] = st.selectbox("Model name", model_options_openai, index=model_options_openai.index(st.session_state["openai"]["model_name"]))
+                    st.session_state["openai"]["model_name"] = st.text_input("Model name", value=st.session_state["openai"].get("model_name", "gpt-3.5-turbo"), help="Enter any modern LLM supported by LiteLLM (e.g., groq/llama3-8b-8192, openai/gpt-4, anthropic/claude-3-sonnet-20240229, together/, ollama/, openrouter/, cerebras/, gemini/, meta/ etc.)")
                     st.session_state["openai"]["temperature"] = st.slider("Temperature", min_value=0.0, max_value=2.0, value=st.session_state["openai"]["temperature"], step=0.1)
                     st.session_state["openai"]["max_tokens"] = st.slider("Maximum Tokens", min_value=1, max_value=4096, value=st.session_state["openai"]["max_tokens"], step=1)
                     


### PR DESCRIPTION
Updated open-ai langchain module in `libs/openai_langchain.py` to use `ChatLiteLLM` from `langchain_community` which provides support for more models. Made `script.py` use a `text_input` rather than `selectbox` so any supported litellm prefix and model can be used. Updated `requirements.txt` to include `litellm` and `langchain-community`.

---
*PR created automatically by Jules for task [17913494708542242998](https://jules.google.com/task/17913494708542242998) started by @haseeb-heaven*