### PR TITLE
🎨 Palette: Add loading spinners for long-running operations

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-08 - Added Visual Loading Indicators
+**Learning:** During long-running AI API calls or code compilation in Streamlit apps, the lack of immediate visual feedback makes the interface feel unresponsive. Users might repeatedly click buttons or wonder if the app is frozen.
+**Action:** Always wrap long-running operations triggered by buttons (like AI generation or external API calls) with `with st.spinner("..."):` in Streamlit apps to provide immediate, clear feedback.

--- a/script.py
+++ b/script.py
@@ -309,111 +309,115 @@ def main():
             generate_submitted = st.form_submit_button(button_label)
             
             if generate_submitted:
-                if st.session_state.ai_option == "Open AI":
-                    if st.session_state.openai_langchain:
-                        st.session_state.generated_code = st.session_state.openai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                    else:# Reinitialize the chain
-                        if api_key == None:
-                            st.toast("Open AI API key is not initialized.", icon="❌")
-                            logger.error("Open AI API key is not initialized.")
-                        else:
-                            st.session_state.openai_langchain = OpenAILangChain(api_key,st.session_state.code_language,st.session_state["openai"]["temperature"],st.session_state["openai"]["max_tokens"],st.session_state["openai"]["model_name"])
+                with st.spinner('Generating code...'):
+                    if st.session_state.ai_option == "Open AI":
+                        if st.session_state.openai_langchain:
                             st.session_state.generated_code = st.session_state.openai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                elif st.session_state.ai_option == "Vertex AI":
-                    if st.session_state.vertexai_langchain:
-                        if not st.session_state.vertex_ai_loaded:
-                            st.toast("Vetex AI is not initialized.", icon="❌")
-                            logger.error("Vetex AI is not initialized.")
-                            return
-                        if st.session_state["vertexai"]["model_name"] == "code-bison":
+                        else:# Reinitialize the chain
+                            if api_key == None:
+                                st.toast("Open AI API key is not initialized.", icon="❌")
+                                logger.error("Open AI API key is not initialized.")
+                            else:
+                                st.session_state.openai_langchain = OpenAILangChain(api_key,st.session_state.code_language,st.session_state["openai"]["temperature"],st.session_state["openai"]["max_tokens"],st.session_state["openai"]["model_name"])
+                                st.session_state.generated_code = st.session_state.openai_langchain.generate_code(st.session_state.code_prompt, code_language)
+                    elif st.session_state.ai_option == "Vertex AI":
+                        if st.session_state.vertexai_langchain:
+                            if not st.session_state.vertex_ai_loaded:
+                                st.toast("Vetex AI is not initialized.", icon="❌")
+                                logger.error("Vetex AI is not initialized.")
+                                return
+                            if st.session_state["vertexai"]["model_name"] == "code-bison":
+                                st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code(st.session_state.code_prompt, code_language)
+                            else:
+                                st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code_completion(st.session_state.code_prompt, code_language)
+                        else: # Reinitalize the chain
+                            st.session_state.vertexai_langchain= VertexAILangChain(project=st.session_state.project, location=st.session_state.region, model_name=st.session_state["vertexai"]["model_name"], max_tokens=st.session_state["vertexai"]["max_tokens"], temperature=st.session_state["vertexai"]["temperature"], credentials_file_path=credentials_file_path)
+                            st.session_state.vertex_ai_loaded = st.session_state.vertexai_langchain.load_model(st.session_state["vertexai"]["model_name"],st.session_state["vertexai"]["max_tokens"],st.session_state["vertexai"]["temperature"])
                             st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                        else:
-                            st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code_completion(st.session_state.code_prompt, code_language)
-                    else: # Reinitalize the chain
-                        st.session_state.vertexai_langchain= VertexAILangChain(project=st.session_state.project, location=st.session_state.region, model_name=st.session_state["vertexai"]["model_name"], max_tokens=st.session_state["vertexai"]["max_tokens"], temperature=st.session_state["vertexai"]["temperature"], credentials_file_path=credentials_file_path)
-                        st.session_state.vertex_ai_loaded = st.session_state.vertexai_langchain.load_model(st.session_state["vertexai"]["model_name"],st.session_state["vertexai"]["max_tokens"],st.session_state["vertexai"]["temperature"])
-                        st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                
-                elif st.session_state.ai_option == "Palm AI":
-                    if st.session_state.palm_langchain:
-                        st.session_state.generated_code = st.session_state.palm_langchain.generate_code(st.session_state.code_prompt, code_language)
-                    else:# Reinitialize the chain
-                        if api_key == None:
-                            st.toast("Palm AI API key is not initialized.", icon="❌")
-                            logger.error("Palm AI API key is not initialized.")
-                        else:
-                            st.session_state.palm_langchain = PalmAI(api_key, model=st.session_state["palm"]["model_name"], temperature=st.session_state["palm"]["temperature"], max_output_tokens=st.session_state["palm"]["max_tokens"])
+
+                    elif st.session_state.ai_option == "Palm AI":
+                        if st.session_state.palm_langchain:
                             st.session_state.generated_code = st.session_state.palm_langchain.generate_code(st.session_state.code_prompt, code_language)
-            
-                elif st.session_state.ai_option == "Gemini AI":
-                    if st.session_state.gemini_langchain:
-                        st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
-                    else:# Reinitialize the chain
-                        if api_key == None:
-                            st.toast("Gemini AI API key is not initialized.", icon="❌")
-                            logger.error("Gemini AI API key is not initialized.")
-                        else:
-                            st.session_state.gemini_langchain = GeminiAI(api_key, model=st.session_state["gemini"]["model_name"], temperature=st.session_state["gemini"]["temperature"], max_output_tokens=st.session_state["gemini"]["max_tokens"])
-                            st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
+                        else:# Reinitialize the chain
+                            if api_key == None:
+                                st.toast("Palm AI API key is not initialized.", icon="❌")
+                                logger.error("Palm AI API key is not initialized.")
+                            else:
+                                st.session_state.palm_langchain = PalmAI(api_key, model=st.session_state["palm"]["model_name"], temperature=st.session_state["palm"]["temperature"], max_output_tokens=st.session_state["palm"]["max_tokens"])
+                                st.session_state.generated_code = st.session_state.palm_langchain.generate_code(st.session_state.code_prompt, code_language)
                 
-                else:
-                    st.toast(f"Please select a valid AI option selected '{st.session_state.ai_option}' option", icon="❌")
-                    st.session_state.generated_code = ""
-                    logger.error(f"Please select a valid AI option selected '{st.session_state.ai_option}' option")
+                    elif st.session_state.ai_option == "Gemini AI":
+                        if st.session_state.gemini_langchain:
+                            st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
+                        else:# Reinitialize the chain
+                            if api_key == None:
+                                st.toast("Gemini AI API key is not initialized.", icon="❌")
+                                logger.error("Gemini AI API key is not initialized.")
+                            else:
+                                st.session_state.gemini_langchain = GeminiAI(api_key, model=st.session_state["gemini"]["model_name"], temperature=st.session_state["gemini"]["temperature"], max_output_tokens=st.session_state["gemini"]["max_tokens"])
+                                st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
+
+                    else:
+                        st.toast(f"Please select a valid AI option selected '{st.session_state.ai_option}' option", icon="❌")
+                        st.session_state.generated_code = ""
+                        logger.error(f"Please select a valid AI option selected '{st.session_state.ai_option}' option")
 
         # Debug Code button in the fourth column
         with debug_code_col:
             debug_submitted = st.form_submit_button("Debug")
             ai_llm_selected = None
             if debug_submitted:
-                # checking for the selected AI option
-                if st.session_state.ai_option == "Palm AI":
-                    ai_llm_selected = st.session_state.palm_langchain
-                elif st.session_state.ai_option == "Gemini AI":
-                    ai_llm_selected = st.session_state.gemini_langchain
-                elif st.session_state.ai_option == "Open AI":
-                    ai_llm_selected = st.session_state.openai_langchain
+                with st.spinner('Debugging code...'):
+                    # checking for the selected AI option
+                    if st.session_state.ai_option == "Palm AI":
+                        ai_llm_selected = st.session_state.palm_langchain
+                    elif st.session_state.ai_option == "Gemini AI":
+                        ai_llm_selected = st.session_state.gemini_langchain
+                    elif st.session_state.ai_option == "Open AI":
+                        ai_llm_selected = st.session_state.openai_langchain
 
-                if not st.session_state.code_fix_instructions:
-                    st.toast("Missing Debug instructions", icon="❌")
-                    logger.warning("Missing Debug instructions")
+                    if not st.session_state.code_fix_instructions:
+                        st.toast("Missing Debug instructions", icon="❌")
+                        logger.warning("Missing Debug instructions")
 
-                if not st.session_state.stderr and st.session_state.code_fix_instructions:
-                    st.session_state.stderr = st.session_state.code_fix_instructions
-                    logger.info("Setting Stderr from input to Debug instructions.")
-                    
-                logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
+                    if not st.session_state.stderr and st.session_state.code_fix_instructions:
+                        st.session_state.stderr = st.session_state.code_fix_instructions
+                        logger.info("Setting Stderr from input to Debug instructions.")
+
+                    logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
+                    st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
         # Debug Code button in the fourth column
         with convert_code_col:
             convert_submitted = st.form_submit_button("Convert")
             ai_llm_selected = None
             if convert_submitted:
-                # checking for the selected AI option
-                if st.session_state.ai_option == "Palm AI":
-                    ai_llm_selected = st.session_state.palm_langchain
-                elif st.session_state.ai_option == "Gemini AI":
-                    ai_llm_selected = st.session_state.gemini_langchain
-                elif st.session_state.ai_option == "Open AI":
-                    ai_llm_selected = st.session_state.openai_langchain
-                    
-                logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
+                with st.spinner('Converting code...'):
+                    # checking for the selected AI option
+                    if st.session_state.ai_option == "Palm AI":
+                        ai_llm_selected = st.session_state.palm_langchain
+                    elif st.session_state.ai_option == "Gemini AI":
+                        ai_llm_selected = st.session_state.gemini_langchain
+                    elif st.session_state.ai_option == "Open AI":
+                        ai_llm_selected = st.session_state.openai_langchain
+
+                    logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
+                    st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
         # Run Code button in the fourth column
         with run_code_col:
             execute_submitted = st.form_submit_button("Execute")
             if execute_submitted:          
-                # Execute the code.
-                privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
-    
-                if privacy_accepted:
-                    st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
-                else:
-                    st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
-                    logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")
+                with st.spinner('Executing code...'):
+                    # Execute the code.
+                    privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
+
+                    if privacy_accepted:
+                        st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
+                    else:
+                        st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
+                        logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")
 
         # Example Code button in the fifth column
         with example_code_col:


### PR DESCRIPTION
💡 **What**: Added `st.spinner()` visual loading indicators to the main long-running operations in the application ("Generate", "Debug", "Convert", and "Execute" code).
🎯 **Why**: When users click buttons that trigger AI model calls or external compilations, the app previously provided no immediate visual feedback, leading to a feeling of unresponsiveness or uncertainty about whether the action was being processed. Adding spinners explicitly solves this, improving the interaction flow and giving users confidence that their request is being handled.
📸 **Before/After**: (Visual change) Previously, clicking "Generate" would just wait until the output appeared. Now, a spinner appears immediately with text like "Generating code...", "Debugging code...", etc., giving immediate visual feedback.
♿ **Accessibility**: Provides clearer state communication (the app is "busy") for all users, which is a key usability heuristic (Visibility of System Status). Also added a critical UX learning to the `.Jules/palette.md` journal.

---
*PR created automatically by Jules for task [11033893006073507844](https://jules.google.com/task/11033893006073507844) started by @haseeb-heaven*