### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix eval() vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [CRITICAL] Replace eval() with st.session_state.get() in Streamlit app
+**Vulnerability:** The code used `eval()` to dynamically check values in Streamlit's `st.session_state` (`eval(var)` where `var` was a string like `'st.session_state.project'`). Using `eval()` is a critical security anti-pattern that can lead to arbitrary code execution if the input is ever controlled or influenced by a malicious user.
+**Learning:** Developers sometimes use `eval()` as a shortcut for dynamic variable access, not realizing the severe security implications. In Streamlit, `st.session_state` is a dictionary-like object and should be accessed safely using keys.
+**Prevention:** Never use `eval()` to dynamically evaluate code strings or check dictionary values. Instead, use safe dictionary access methods like `dict.get(key)` or `st.session_state.get(key)` to retrieve values dynamically based on their keys.

--- a/script.py
+++ b/script.py
@@ -160,15 +160,15 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping session_state keys to descriptions
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The Streamlit app used `eval()` to dynamically check values in `st.session_state` (`eval(var)` where `var` was a string like `'st.session_state.project'`). This is a critical security anti-pattern that can lead to arbitrary code execution if user inputs ever influence the evaluation path.
🎯 **Impact:** If an attacker could inject code into the string evaluated by `eval()`, they could execute arbitrary Python code on the backend server.
🔧 **Fix:** Refactored the `items` dictionary to hold only the `st.session_state` keys instead of stringified variable references. Replaced the `eval()` call with `st.session_state.get(key)`. This safely accesses dictionary values without executing strings as code.
✅ **Verification:** Verified syntax correctness using `python3 -m py_compile script.py` and ran project tests using `PYTHONPATH=. pytest`. Checked manually that the fix maintains the original logical behavior for filtering missing configs. Added the learning to Sentinel's journal.

---
*PR created automatically by Jules for task [14509869639557950497](https://jules.google.com/task/14509869639557950497) started by @haseeb-heaven*