### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution risk via eval()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-03 - [Fix Arbitrary Code Execution Risk via eval()]
+**Vulnerability:** The application used `eval()` to dynamically check values within the `st.session_state` (e.g., `eval("st.session_state.project")`). This is a critical security anti-pattern that can lead to arbitrary code execution if the input strings are ever influenced by user input.
+**Learning:** `eval()` was used as a shortcut to check the truthiness of dynamically generated variable names. However, this pattern bypasses normal type and execution safety mechanisms, making the application vulnerable to injection attacks.
+**Prevention:** Never use `eval()` to dynamically evaluate code strings or check dictionary values. Instead, use safer alternatives like `dict.get(key)` or `st.session_state.get(key)`. Ensure all dynamically checked variables are safely parameterized.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,15 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
+                        # SECURITY: Do not use eval() to dynamically check variables. It is a critical security risk.
+                        # Instead, use safe dictionary access like st.session_state.get(key).
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application used `eval()` to dynamically check values within the `st.session_state` (e.g., `eval("st.session_state.project")`). This is a critical security anti-pattern that can lead to arbitrary code execution if the input strings are ever influenced by user input.
🎯 Impact: An attacker could potentially execute arbitrary Python code on the server if they were able to inject malicious strings into the variable checked by `eval()`.
🔧 Fix: Replaced `eval()` with safe dictionary access using `st.session_state.get()`. Removed the `st.session_state.` prefix from the mapping keys so they represent the actual state keys. Added a security comment explaining the change.
✅ Verification: Ran `python3 -m py_compile script.py` to ensure no syntax errors were introduced. Manually verified the logic visually via `cat`.

---
*PR created automatically by Jules for task [6748598436534135113](https://jules.google.com/task/6748598436534135113) started by @haseeb-heaven*