### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution vulnerability (eval)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-21 - Remove dangerous eval() checking Streamlit session state
+**Vulnerability:** Found `eval()` being used to check if variables like `'st.session_state.project'` were set. This is a critical security anti-pattern that can lead to arbitrary code execution if any input gets into the evaluated string.
+**Learning:** Never use `eval()` to dynamically evaluate code strings or check dictionary values, even for seemingly safe internal state checks.
+**Prevention:** Use safer alternatives like `st.session_state.get(key)` directly with the actual dictionary keys.

--- a/script.py
+++ b/script.py
@@ -160,15 +160,16 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping session state keys to readable names
+                        # Security fix: Removed dangerous eval() call
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The script.py logic for validating VertexAI configuration fields used the python `eval()` function to test if values in `st.session_state` like 'st.session_state.project' evaluated to true. Since `eval` is a powerful function, if any input into it was controlled by a user, it could lead to Arbitrary Code Execution (ACE) on the server.
🎯 Impact: While this instance was largely checking internal static strings representing the UI state, `eval` poses a huge security risk. It provides an exploitable surface area if logic refactoring later allows untrusted input strings to touch it. 
🔧 Fix: Refactored the `items` dictionary to map bare session state keys (e.g. `'project'`) rather than python expressions. I then replaced `eval(var)` with `st.session_state.get(key)`. This safely checks if the state keys hold truthy values.
✅ Verification: Ran `python3 -m py_compile script.py` to ensure syntax is valid and `PYTHONPATH=. pytest` which passed. Additionally verified the sentinel journal update.

---
*PR created automatically by Jules for task [3042715966117626750](https://jules.google.com/task/3042715966117626750) started by @haseeb-heaven*