### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - [CRITICAL] Fix eval() vulnerability in dictionary comprehensions
+**Vulnerability:** Found arbitrary code execution vulnerability where `eval()` was used to dynamically evaluate strings like "st.session_state.project" to check if variables were set.
+**Learning:** Using `eval()` to dynamically check dictionary values or evaluate Python expressions is a critical security anti-pattern that can lead to arbitrary code execution if any part of the string can be influenced by user input.
+**Prevention:** Never use `eval()` to check state. Instead, directly access values using safe methods like `dict.get(key)` or `st.session_state.get(key)`.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
-                        # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        # Use a list comprehension to filter out the unset items safely
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `eval()` was used to dynamically execute Python code strings based on dictionary values, creating a severe arbitrary code execution vulnerability if those strings were ever influenced by user input.
🎯 Impact: Remote code execution (RCE) on the server running Streamlit.
🔧 Fix: Replaced `eval()` with direct mapping of session state keys, using `st.session_state.get(key)` to safely check values.
✅ Verification: Ran `python3 -m py_compile script.py` and `pytest` to ensure no syntactical regressions. Created a journal entry.

---
*PR created automatically by Jules for task [8543875045015011669](https://jules.google.com/task/8543875045015011669) started by @haseeb-heaven*