### PR TITLE
🎨 Palette: Improve accessibility of collapsed Streamlit inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Streamlit Collapsed Labels Accessibility
+**Learning:** In Streamlit UIs, using `label_visibility='collapsed'` on inputs (like `st.text_input`) causes them to lose their accessibility context and label associations, leading to poor UX for screen readers.
+**Action:** When a label must be hidden for layout purposes, always compensate by providing a descriptive `help` tooltip and an actionable `placeholder` example to ensure the input's purpose remains clear.

--- a/script.py
+++ b/script.py
@@ -270,9 +270,9 @@ def main():
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 5, 10, user_input", help="Standard input provided to the code during execution", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. Hello World, 15", help="Expected standard output from the code execution", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix IndexError on line 5", help="Instructions for the AI to debug or fix the generated code", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +294,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. script.py", help="Name of the file to save the generated code as", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What:** Added descriptive `help` tooltips and actionable `placeholder` examples to Streamlit text inputs in `script.py` where the label visibility was set to 'collapsed' (lines 273-275 and 297).
🎯 **Why:** When `label_visibility='collapsed'` is used, the input loses its accessibility context, making it confusing for users, especially those using screen readers, to understand what the input expects. The added placeholders and tooltips restore this context without compromising the UI layout.
📸 **Before/After:** No visual changes for users without hovering. Hovering over the inputs now displays a helpful tooltip explaining the input's purpose. The input itself now features a clearer placeholder example.
♿ **Accessibility:** This significantly improves the experience for users relying on screen readers or those who need extra guidance on what input is expected, effectively mitigating the negative accessibility impact of hidden labels.

---
*PR created automatically by Jules for task [4590874791085697295](https://jules.google.com/task/4590874791085697295) started by @haseeb-heaven*