### PR TITLE
🎨 Palette: [Accessibility] Improve Streamlit collapsed labels with tooltips and actionable placeholders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility of Streamlit Collapsed Labels
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` lose accessibility context because screen readers and users cannot see the label.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples for all inputs with collapsed labels.

--- a/script.py
+++ b/script.py
@@ -270,9 +270,9 @@ def main():
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 1 2 3", help="Standard input for the code execution", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. 6", help="Expected standard output for verification", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the index out of bounds error", help="Instructions for fixing the code if it fails", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +294,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Name of the file to save the code to", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added `help` tooltips and descriptive `placeholder` examples to all `st.text_input` fields that use `label_visibility='collapsed'`.

🎯 Why: In Streamlit UI, inputs using `label_visibility='collapsed'` lose accessibility context because screen readers and users cannot see the label. Adding these attributes compensates for the missing labels.

📸 Before/After: Visual changes add a tooltip hover icon and change empty input field placeholders from repeating the label ("Input (Stdin)") to examples ("e.g. 1 2 3").

♿ Accessibility: Significantly improves keyboard navigation context and screen reader interpretability by making sure all interactive inputs have clear, accessible guidance.

---
*PR created automatically by Jules for task [2060699038701355910](https://jules.google.com/task/2060699038701355910) started by @haseeb-heaven*