### PR TITLE
🎨 Palette: Improve accessibility of hidden Streamlit inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-25 - Improve accessibility of hidden Streamlit labels
+**Learning:** In Streamlit UIs, using `label_visibility='collapsed'` or `hidden` causes elements to lose accessibility context for screen readers.
+**Action:** Always provide descriptive `help` tooltips and actionable `placeholder` examples for inputs that have their labels hidden or collapsed to maintain accessibility and user context.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        placeholder="e.g. Write a Python function to calculate the Fibonacci sequence..." if 'code_prompt' not in st.session_state else "",
+        label_visibility='hidden',
+        help="Describe the application or code you want the AI to generate."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 5, 10, 15", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input for the code execution.")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. Expected output format", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output to match against.")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the index out of bounds error", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Provide specific instructions for debugging the code.")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. script.py", label_visibility='collapsed', help="Name of the file to save the generated code to.")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What:** Added descriptive `help` attributes and actionable `placeholder` texts to several Streamlit inputs (`st.text_input`, `st.text_area`) that had their `label_visibility` set to `hidden` or `collapsed`. Also added an entry to Palette's journal recording this critical learning.

🎯 **Why:** When Streamlit inputs have their labels hidden or collapsed, they lose accessibility context for screen readers. Providing tooltips and actionable placeholders helps users understand what is expected in those fields.

📸 **Before/After:**
- Before: Inputs like Stdin, Stdout, and File Name just had generic placeholders matching their labels, and no help text.
- After: They now feature actionable placeholders (e.g., "e.g. 5, 10, 15", "e.g. script.py") and explicit `help` text providing context.

♿ **Accessibility:** This significantly improves accessibility by ensuring that even when a visible label is missing, screen readers can interpret the `help` attribute, and users are guided properly by concrete placeholder examples.

---
*PR created automatically by Jules for task [6740580911205361806](https://jules.google.com/task/6740580911205361806) started by @haseeb-heaven*