### PR TITLE
🎨 Palette: Add accessibility tooltips to Streamlit inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Streamlit label_visibility and Accessibility
+**Learning:** In Streamlit, setting `label_visibility='collapsed'` or `'hidden'` on input elements removes visual clutter but causes them to lose their accessibility context for screen readers.
+**Action:** Always provide a descriptive `help` tooltip parameter alongside a `placeholder` when hiding Streamlit input labels to maintain accessibility and provide context.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Enter the prompt or code for the AI model to generate or complete."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input for the code execution.")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output for the code execution.")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Instructions to help the AI model debug the code.")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed', help="Name of the file to save the generated code.")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added the `help` parameter to several text inputs and text areas in `script.py` (specifically `code_prompt`, `code_input`, `code_output`, `code_fix_instructions`, and `code_file`).
🎯 Why: In Streamlit, inputs with `label_visibility='collapsed'` or `'hidden'` lose context for screen readers and users when the placeholder disappears upon typing. The `help` string restores this critical accessibility context and serves as a descriptive tooltip.
📸 Before/After: Visuals will now show an info tooltip icon next to these input fields if visible, or provide context to screen readers even when the label is technically hidden/collapsed.
♿ Accessibility: Improved screen reader support and general context by providing tooltips for inputs without visible labels. Added a learning to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [429264889921824858](https://jules.google.com/task/429264889921824858) started by @haseeb-heaven*