### PR TITLE
🎨 Palette: Add accessibility tooltips to hidden label inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Missing accessibility context for inputs with hidden labels
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples to these inputs to restore the missing context.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Enter the prompt or code instructions you want the AI to process"
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input for the code execution")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output for the code execution")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Instructions for the AI to debug or fix the code")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed', help="Name of the file to download or save as")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added `help` parameters to Streamlit text inputs and text areas that had their labels hidden or collapsed (`label_visibility="hidden"` or `"collapsed"`).
🎯 Why: In Streamlit, when an input's label is hidden or collapsed, it loses accessibility context for screen readers and users who rely on supplementary information to understand the input's purpose.
📸 Before/After: Inputs like the main code prompt, stdin/stdout boxes, debug instructions, and the file name input now feature descriptive tooltips (`?` icon) that explain their functionality, whereas before they provided no semantic or visual explanation of their purpose when the label was removed.
♿ Accessibility: Ensures that interactive form elements provide adequate context even when their primary visible label is removed for layout purposes, satisfying basic WCAG guidelines for form context and screen-reader usability. Also added a journal entry in `.Jules/palette.md` to document this Streamlit-specific pattern.

---
*PR created automatically by Jules for task [8514657079638585339](https://jules.google.com/task/8514657079638585339) started by @haseeb-heaven*