### PR TITLE
🎨 Palette: [Accessibility] Add tooltips to hidden labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - Accessible Hidden Labels in Streamlit
+**Learning:** When using `label_visibility='collapsed'` or `'hidden'` in Streamlit, inputs lose accessibility context for screen readers because the label is removed from the DOM.
+**Action:** Always provide descriptive `help` tooltips and/or actionable `placeholder` text as a fallback to maintain accessibility when visual labels are hidden.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Enter a description of the code you want to generate."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Provide standard input (stdin) for execution", help="Standard input for the code execution.", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Expected standard output (stdout)", help="Expected standard output for the code execution.", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Instructions for fixing the code", help="Instructions for fixing or debugging the code.", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Name of the file to save the code to.", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What**
Added `help` parameters and improved `placeholder` examples for `st.text_input` and `st.text_area` calls in `script.py` where `label_visibility='collapsed'` or `label_visibility='hidden'` are used. 

🎯 **Why**
When labels are hidden or collapsed in Streamlit, they are removed from the DOM, causing them to lose their accessibility context for screen readers. Providing tooltips and better placeholders acts as a fallback.

📸 **Before/After**
N/A (Visual difference is only tooltips when hovering, and slightly different placeholder text).

♿ **Accessibility**
Screen readers will now have context from the `help` attributes for the visually hidden labels.

---
*PR created automatically by Jules for task [6951657748468808351](https://jules.google.com/task/6951657748468808351) started by @haseeb-heaven*