### PR TITLE
🎨 Palette: Add context to hidden-label Streamlit inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Streamlit Input Accessibility
+**Learning:** When using `label_visibility='hidden'` or `'collapsed'` in Streamlit inputs, the semantic accessibility context is lost for screen readers.
+**Action:** Always provide descriptive `help` tooltips and clear, actionable `placeholder` text to compensate for the hidden labels and maintain accessibility.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,12 @@
+1. **Add `help` tooltips and actionable `placeholder`s to Streamlit inputs**
+   - Modify `script.py` to add `help` text and descriptive placeholders to `st.text_area` and `st.text_input` elements that use `label_visibility='hidden'` or `'collapsed'`, compensating for lost accessibility context.
+   - Specifically target `code_prompt`, `code_input`, `code_output`, `code_fix_instructions`, and `code_file` using `replace_with_git_merge_diff`.
+2. **Create UX journal entry**
+   - Create `.Jules/palette.md` (and the directory) to document the critical learning about `label_visibility` accessibility in Streamlit.
+3. **Verify the syntax**
+   - Run `python3 -m py_compile script.py` to ensure the Python code has correct syntax.
+   - Run `cat .Jules/palette.md` to verify the journal entry creation.
+4. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+   - Run `pre_commit_instructions` and follow the steps.
+5. **Submit the change**
+   - Commit and submit the code with a descriptive commit message formatted for Palette PRs.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
+        placeholder="e.g. Write a python function to print primes" if 'code_prompt' not in st.session_state else "",
+        help="Provide instructions for the AI to generate code from.",
         label_visibility='hidden'
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 5 (for input stdin)", help="Standard input variables to be passed to the executed code.", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. 120 (for output stdout)", help="Expected standard output for the given input.", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix indentation error on line 5", help="Instructions provided to debug and fix the generated code.", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Name of the file to save the generated code as.", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What
Added `help` tooltips and descriptive, actionable `placeholder` texts to Streamlit input components (`st.text_area`, `st.text_input`) that were using `label_visibility='hidden'` or `'collapsed'`.

🎯 Why
When `label_visibility` is hidden or collapsed in Streamlit, the semantic accessibility context is lost. Screen readers might not adequately convey the purpose of the input to the user. Providing `help` tooltips and actionable `placeholder` examples helps to compensate for this missing context and improves the overall experience for all users.

📸 Before/After
Before:
Inputs like "Enter Prompt" had a placeholder "Enter your prompt for code generation." and no tooltips. The labels were completely hidden or collapsed without contextual hints.

After:
Inputs have clearer, example-driven placeholders (e.g., `e.g. Write a python function to print primes`) and descriptive `help` tooltips explaining their purpose (e.g., `Provide instructions for the AI to generate code from.`), ensuring users understand the input requirements even without a visible label.

♿ Accessibility
Restores context for screen reader users and improves general usability for hidden-label inputs by leveraging standard Streamlit `help` and `placeholder` features.

---
*PR created automatically by Jules for task [14603201835050012435](https://jules.google.com/task/14603201835050012435) started by @haseeb-heaven*