### PR TITLE
🎨 Palette: Add context tooltips for hidden labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-06-01 - [Context Loss in Streamlit Inputs]
+**Learning:** When using Streamlit UI components like `st.text_input` and `st.text_area` with `label_visibility='hidden'` or `label_visibility='collapsed'`, screen readers and users lose critical context about what the field is for, significantly reducing accessibility.
+**Action:** Always compensate for hidden labels by providing a descriptive `help` tooltip and actionable `placeholder` examples so that the purpose of the input remains clear.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Provide a detailed prompt for the AI to generate code from."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 5, 10, 'hello'", help="Standard input for the code execution", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. 15, 'world'", help="Expected standard output to verify against", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the index out of bounds error", help="Provide instructions on what to fix or debug in the code", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Enter a filename to save your code", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What
Added descriptive `help` tooltips and specific, actionable `placeholder` examples to several Streamlit `st.text_input` and `st.text_area` fields that previously used `label_visibility='hidden'` or `'collapsed'`.

🎯 Why
When labels are hidden or collapsed in Streamlit, users (especially those relying on screen readers) lose context about what the field is for. Adding a `help` attribute and a more descriptive `placeholder` restores this context without cluttering the visual UI.

📸 Before/After
Before: Placeholder was "Input (Stdin)" and there was no tooltip.
After: Placeholder is "e.g. 5, 10, 'hello'" and hovering/focusing shows "Standard input for the code execution".

♿ Accessibility
Significantly improves screen reader experience and general usability by ensuring hidden labels do not result in a loss of context for interactive form elements.

---
*PR created automatically by Jules for task [131289773812576276](https://jules.google.com/task/131289773812576276) started by @haseeb-heaven*