### PR TITLE
🎨 Palette: Add helpful placeholders and tooltips to inputs with hidden labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-02 - Streamlit Hidden Labels Accessibility
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
+        placeholder="e.g. Write a python function to calculate fibonacci sequence",
+        help="Enter the detailed instructions or prompt for the AI to generate code.",
         label_visibility='hidden'
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 5, 10, or 'Hello'", help="Standard input for executing the code", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. 55", help="Expected standard output to match against", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix IndexError on line 12", help="Instructions for the AI on what to fix or debug", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Name of the file to download as", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added descriptive `help` tooltips and actionable `placeholder` examples to several `st.text_input` and `st.text_area` fields in `script.py` where `label_visibility` was set to `'hidden'` or `'collapsed'`.
🎯 Why: Streamlit inputs with hidden labels lose critical context for screen readers. This micro-UX improvement compensates for that loss of context.
📸 Before/After: Inputs previously showed redundant text like "Input (Stdin)" as placeholders. Now they show actionable examples like "e.g. 5, 10, or 'Hello'" and provide helpful tooltips.
♿ Accessibility: Improves context for screen readers when encountering hidden labels.

---
*PR created automatically by Jules for task [3247401525007489209](https://jules.google.com/task/3247401525007489209) started by @haseeb-heaven*