### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility for hidden labels in Streamlit inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Streamlit Hidden Labels Accessibility
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Type the instructions or code snippet you want the AI to process."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. user input values", help="Standard input values to pass to your program during execution.", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. expected output", help="Expected output for verification.", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the indentation error", help="Provide specific instructions for the AI to debug the generated code.", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Enter the desired file name to save the generated code.", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added contextual `help` tooltips and actionable `placeholder` examples to Streamlit input fields (`st.text_area` and `st.text_input`) that were using `label_visibility='hidden'` or `'collapsed'`.
🎯 Why: In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers and can confuse sighted users as well. Providing these attributes restores meaning to those inputs.
📸 Before/After: The inputs for prompting, stdin, stdout, debug instructions, and filename now have clear example placeholders and descriptive tooltips when hovered over.
♿ Accessibility: Improves screen reader compatibility by explicitly defining the purpose of hidden-label input fields using `help` (which maps to aria-description or similar mechanisms depending on the Streamlit version) and `placeholder`.

---
*PR created automatically by Jules for task [14693445232320538027](https://jules.google.com/task/14693445232320538027) started by @haseeb-heaven*