### PR TITLE
🎨 Palette: Improve accessibility of inputs with collapsed labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-05 - Accessible Inputs with Hidden Labels
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples to maintain context and accessibility.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        placeholder="Enter your prompt for code generation. e.g. Write a function to calculate Fibonacci sequence." if 'code_prompt' not in st.session_state else "",
+        label_visibility='hidden',
+        help="Prompt for the AI to generate code. Provide a clear description."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input for the code (e.g. Test case inputs)", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input for the code execution.")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Expected output (e.g. Test case results)", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output from the code execution.")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Instructions for debugging (e.g. Fix NameError)", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Provide instructions on what to fix or debug in the code.")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="File name (e.g. main.py)", label_visibility='collapsed', help="Provide a name for the file to be saved/downloaded.")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What:** 
Added `help` tooltips and descriptive `placeholder` texts to several Streamlit inputs (`code_prompt`, `code_input`, `code_output`, `code_fix_instructions`, and `code_file`) that use `label_visibility='hidden'` or `label_visibility='collapsed'`. Also recorded this learning in `.jules/palette.md`.

🎯 **Why:**
When Streamlit widgets hide or collapse their labels visually, they can lose their primary context, especially for screen readers or users tabbing through the interface. This makes it difficult to understand what the input is for.

📸 **Before/After:**
*   **Before:** Inputs had generic or empty placeholders and no tooltips, relying solely on visual context or adjacent elements which might not be clear to all users or screen readers.
*   **After:** Inputs now have descriptive tooltips (`help` arg) providing clear instructions when hovered, and actionable example placeholders guiding the user on what to input.

♿ **Accessibility:**
*   Improved context for screen reader users when navigating to inputs with collapsed labels.
*   Provided clearer guidance for all users through informative tooltips and practical placeholder examples, reducing cognitive load.

---
*PR created automatically by Jules for task [9096961471185508535](https://jules.google.com/task/9096961471185508535) started by @haseeb-heaven*