### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval() vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-05 - Removed eval() usage
+**Vulnerability:** Arbitrary code execution via `eval()`.
+**Learning:** Never use `eval()` to dynamically evaluate code strings or check dictionary values. It is a security anti-pattern.
+**Prevention:** Instead, use safer alternatives like `dict.get(key)` or `st.session_state.get(key)`.

--- a/script.py
+++ b/script.py
@@ -160,15 +160,16 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping session state keys to their readable names
+                        # SECURITY: Avoiding eval() by checking session state keys directly
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `script.py` file used `eval()` to dynamically evaluate strings containing `st.session_state` variable names to check if they were set. This is a significant security anti-pattern as `eval()` can execute arbitrary Python code if the input string is ever influenced by a malicious actor, leading to Remote Code Execution (RCE).
🎯 **Impact:** While the current usage was bounded by a hardcoded dictionary, establishing a pattern of using `eval()` for simple dictionary or state lookups is highly dangerous. If this pattern were replicated elsewhere with user input, it could lead to complete system compromise.
🔧 **Fix:** 
- Replaced the stringified code mappings (`'st.session_state.project'`) with their literal string keys (`'project'`).
- Replaced the list comprehension condition `if not eval(var)` with `if not st.session_state.get(key)`. This achieves the exact same functional outcome (checking if a required session state variable is missing) but uses the safe, standard dictionary accessor method.
- Added a Sentinel journal entry detailing the learning to avoid `eval()`.
✅ **Verification:** 
- The script passes `python3 -m py_compile script.py` successfully.
- `eval()` is no longer present in the targeted block in `script.py`.

---
*PR created automatically by Jules for task [7153338632180078570](https://jules.google.com/task/7153338632180078570) started by @haseeb-heaven*