### PR TITLE
🎨 Palette: Add tooltips for accessibility on hidden labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-06 - Streamlit Label Visibility Accessibility
+**Learning:** When using `label_visibility='collapsed'` or `'hidden'` in Streamlit inputs, the input loses its accessibility context for screen readers and visual context for users.
+**Action:** Compensate for hidden labels by always providing descriptive `help` tooltips and actionable `placeholder` examples to ensure accessibility and usability.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
+        help="Describe what code you want to generate or complete",
         label_visibility='hidden'
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. hello world (stdin)", help="Standard input passed to the executed code", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. output format (stdout)", help="Expected standard output from the executed code", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix syntax error on line 5", help="Instructions for the AI to debug or fix the code", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Name of the file to save code as", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What**: Added `help` tooltips and descriptive `placeholder` examples to several input fields in `script.py` (like Prompt, Stdin, Stdout, Debug instructions, and File name) that previously used `label_visibility='hidden'` or `'collapsed'`.

🎯 **Why**: When Streamlit input labels are visually hidden or collapsed, the input loses its context for screen readers, and users have less visual context for what they should type. These changes compensate for the missing labels, making the interface more intuitive and accessible.

📸 **Before/After**:
- *Before*: Inputs lacked tooltips, and some had generic placeholders like "Input (Stdin)".
- *After*: Hovering over inputs now displays helpful tooltips (e.g., "Standard input passed to the executed code"), and placeholders provide actionable examples (e.g., "e.g. hello world (stdin)").

♿ **Accessibility**: Restores essential context for screen readers interacting with these inputs and improves general usability for all users.

---
*PR created automatically by Jules for task [14030299596217690454](https://jules.google.com/task/14030299596217690454) started by @haseeb-heaven*