### PR TITLE
🎨 Palette: Add accessibility tooltips for inputs with hidden labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Streamlit Inputs with Hidden Labels
+**Learning:** In Streamlit, setting `label_visibility='collapsed'` or `'hidden'` on inputs (`st.text_input`, `st.text_area`) causes screen readers and users to lose context about what the input is for.
+**Action:** When hiding labels for layout reasons, always compensate by providing a descriptive `help` tooltip and an actionable `placeholder` with an example.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        placeholder="Enter your prompt for code generation (e.g., 'Write a python script to reverse a string')" if 'code_prompt' not in st.session_state else "",
+        label_visibility='hidden',
+        help="Main input area for AI code generation prompts"
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Optional program input data (e.g., test cases)", label_visibility='collapsed', value=st.session_state.code_input, help="Standard input provided to your code during execution")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Expected program output data", label_visibility='collapsed', value=st.session_state.code_output, help="Expected standard output for verification")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Specific instructions for fixing the code", label_visibility='collapsed', value=st.session_state.code_fix_instructions, help="Additional context for debugging when things go wrong")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="Filename (e.g., script.py)", label_visibility='collapsed', help="Filename to use when downloading the generated code")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added `help` tooltips and descriptive, actionable `placeholder` texts to Streamlit input fields (`st.text_area` and `st.text_input`) in `script.py` where `label_visibility` was set to `hidden` or `collapsed`.
🎯 Why: In Streamlit, hiding a label removes context for screen readers and sighted users. These changes compensate for that by providing inline guidance and examples.
📸 Before/After: Visual changes include tooltips on hover and more descriptive placeholder texts (e.g., "Enter your prompt for code generation (e.g., 'Write a python script to reverse a string')" instead of "Enter your prompt for code generation.").
♿ Accessibility: Improved screen reader context for core text inputs and text areas, ensuring users know exactly what to type even without visible labels. Also added a learning about this to the `.jules/palette.md` UX journal.

---
*PR created automatically by Jules for task [12436256315058296560](https://jules.google.com/task/12436256315058296560) started by @haseeb-heaven*