### PR TITLE
🎨 Palette: Add tooltips to inputs with hidden labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-09 - Streamlit Accessibility Context Loss
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples to maintain a11y context.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        placeholder="e.g. Write a python script to parse a csv file" if 'code_prompt' not in st.session_state else "",
+        label_visibility='hidden',
+        help="Provide clear instructions for the code you want the AI to generate."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. Test input for your script", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input data provided to the script during execution")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. Expected output from your script", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output to compare against the script's results")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the index out of bounds error", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Provide instructions on what needs fixing or debugging")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. script.py", label_visibility='collapsed', help="Filename to save the generated code")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added `help` tooltips and actionable `placeholder` examples to Streamlit inputs (`st.text_input` and `st.text_area`) that had `label_visibility='hidden'` or `'collapsed'`. Also documented this accessibility consideration in `.jules/palette.md`.
🎯 Why: In Streamlit, inputs with hidden or collapsed labels lose their accessibility context for screen readers. By providing descriptive help tooltips and clear placeholders, we compensate for this loss and make the interface more intuitive and accessible for all users.
📸 Before/After: Before, fields like "File name" or "Input (Stdin)" just had the generic name or nothing helpful when hovered. After, they provide examples and descriptions (e.g. `placeholder="e.g. script.py"`, `help="Filename to save the generated code"`).
♿ Accessibility: Improved screen reader context and overall user understanding by adding descriptive `help` tooltips to input fields that lack visible labels.

---
*PR created automatically by Jules for task [15496146607041515319](https://jules.google.com/task/15496146607041515319) started by @haseeb-heaven*