### PR TITLE
🎨 Palette: Add context to inputs with hidden labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-11 - Hidden labels accessibility in Streamlit
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples to retain context.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Provide a detailed description of the code you want the AI to generate."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g., 5 10 (Inputs separated by space)", label_visibility='collapsed',value=st.session_state.code_input, help="Provide standard input (stdin) for the code execution.")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g., 15 (Expected output)", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output (stdout) for testing the generated code.")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g., Fix the off-by-one error in the loop", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Instructions for how the AI should debug or fix the code.")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g., main.py", label_visibility='collapsed', help="The filename to save the generated code.")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added `help` tooltips and descriptive `placeholder` strings to `st.text_input` and `st.text_area` fields in `script.py`.
🎯 Why: Inputs using `label_visibility='collapsed'` or `'hidden'` in Streamlit lose context for both screen readers and visual users. Compensating with tooltips and example-driven placeholders makes the interface more intuitive and accessible.
📸 Before/After: Before, inputs like "Input (Stdin)" just had "Input (Stdin)" as placeholder and no tooltip. After, they have placeholders like "e.g., 5 10 (Inputs separated by space)" and a tooltip explaining their purpose.
♿ Accessibility: Improves accessibility for screen readers by providing context through the `help` parameter when the main label is visually hidden or collapsed.

---
*PR created automatically by Jules for task [318390362551269039](https://jules.google.com/task/318390362551269039) started by @haseeb-heaven*