### PR TITLE
🎨 Palette: Add tooltips and actionable placeholders for collapsed inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Streamlit Hidden Labels Accessibility
+**Learning:** In Streamlit, inputs that use `label_visibility='collapsed'` or `'hidden'` lose their accessibility context for screen readers.
+**Action:** Compensate for hidden/collapsed labels by providing descriptive `help` tooltips and actionable `placeholder` examples so that screen readers and visually impaired users can still understand the input's purpose.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
+        placeholder="Enter your prompt for code generation (e.g. Write a function to reverse a string)." if 'code_prompt' not in st.session_state else "",
+        help="Describe the task for the AI to generate code for.",
         label_visibility='hidden'
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin) e.g. 5", help="Standard input for the code execution.", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Expected Output (Stdout) e.g. 120", help="Expected standard output for the code execution.", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions e.g. Fix the indentation error", help="Instructions for the AI to debug or fix the generated code.", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="File name e.g. main.py", help="File name to save the generated code.", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What:** 
Added descriptive `help` tooltips and actionable examples to `placeholder` strings for Streamlit inputs in `script.py` (specifically `code_prompt`, `code_input`, `code_output`, `code_fix_instructions`, and `code_file`) that use `label_visibility='collapsed'` or `'hidden'`.

🎯 **Why:** 
In Streamlit, inputs that hide or collapse their labels visually also lose their semantic meaning and context for screen readers. By adding explicit `help` parameters and detailed `placeholder` texts, we restore context and provide clear expectations to all users without compromising the visual design.

📸 **Before/After:**
- **Before:** `<textarea placeholder="Enter your prompt for code generation."></textarea>` (with no tooltips or guidance on format).
- **After:** `<textarea placeholder="Enter your prompt for code generation (e.g. Write a function to reverse a string)." help="Describe the task for the AI to generate code for."></textarea>` (now provides format guidance and a screen-reader accessible tooltip).

♿ **Accessibility:**
- Significantly improves screen reader experience by providing explicit context for input fields that previously lacked visible labels.
- Adds actionable examples directly within placeholders to guide users on expected input formats.

---
*PR created automatically by Jules for task [15867283949565346919](https://jules.google.com/task/15867283949565346919) started by @haseeb-heaven*