### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file operations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-12 - Prevent Path Traversal in File Operations
+**Vulnerability:** Path traversal in file save and upload operations allowed arbitrary file writes outside intended directories via unsanitized filenames.
+**Learning:** User-provided filenames from UI inputs or file uploads must never be trusted directly in file operations, as they can overwrite critical source code.
+**Prevention:** Always sanitize user-provided filenames using `os.path.basename()` before using them in file system operations like `os.path.join()` or `open()`.

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -296,6 +296,7 @@ class GeneralUtils:
                 logger.error("Error in code saving: Please enter a valid file name.")
                 return
             
+            file_name = os.path.basename(file_name)
             file_extension = file_name.split(".")[-1]
             logger.info(f"Saving code to file: {file_name} with extension: {file_extension}")
             
@@ -412,7 +413,8 @@ class GeneralUtils:
             os.makedirs(temp_dir, exist_ok=True)
             
             logger.info(f"Saving uploaded file to {temp_dir}")
-            file_path = os.path.join(temp_dir, uploadedfile.name)
+            safe_filename = os.path.basename(uploadedfile.name)
+            file_path = os.path.join(temp_dir, safe_filename)
             with open(file_path, "wb") as f:
                 f.write(uploadedfile.getbuffer())
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal vulnerability in `libs/general_utils.py` within the `save_code` and `save_uploaded_file_temp` functions. User-provided filenames were concatenated directly with directory paths without sanitization, allowing malicious path manipulation (e.g., `../../../etc/passwd`).
🎯 Impact: An attacker could write files to arbitrary locations on the host system, potentially overwriting critical source code or system configurations, leading to remote code execution or data destruction.
🔧 Fix: Wrapped the user-provided filenames (`file_name` and `uploadedfile.name`) with `os.path.basename()` before they are used in file operations (`open()` and `os.path.join()`). This ensures only the base filename is used and strips away any malicious directory traversal patterns.
✅ Verification: Verified syntax correctness by running `python3 -m py_compile libs/general_utils.py` and ran the standard test suite. Also added a `sentinel.md` journal entry.

---
*PR created automatically by Jules for task [7343916389741196135](https://jules.google.com/task/7343916389741196135) started by @haseeb-heaven*