### PR TITLE
🎨 Palette: [UX improvement] Add tooltips to collapsed-label inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-13 - Add tooltips to inputs with collapsed labels
+**Learning:** In Streamlit, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
+        help="Enter your prompt for code generation.",
         label_visibility='hidden'
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", help="Provide standard input for the code execution.", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", help="Expected standard output for verification.", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", help="Provide instructions on how to debug or fix the code.", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="File name", help="Name of the file to save the code to.", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added `help` tooltips to Streamlit `st.text_input` and `st.text_area` fields where `label_visibility` is 'collapsed' or 'hidden' (e.g., code_prompt, code_input, code_output, code_fix_instructions, and code_file).
🎯 Why: To restore accessibility context and improve usability for fields that visually hide their labels, preventing screen reader users and general users from losing context.
📸 Before/After: Before, collapsed-label inputs had no tooltips. Now, hovering over them displays a helpful description.
♿ Accessibility: Ensures that even when a visible label is removed for design reasons, the purpose of the input is still exposed to assistive technologies via the `help` attribute (which Streamlit renders as a tooltip and maps to ARIA properties).

---
*PR created automatically by Jules for task [8279000746479927988](https://jules.google.com/task/8279000746479927988) started by @haseeb-heaven*