### PR TITLE
🎨 Palette: Add accessibility context to collapsed labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-14 - Accessibility for hidden labels in Streamlit
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        placeholder="e.g. Write a python script that calculates the Fibonacci sequence" if 'code_prompt' not in st.session_state else "",
+        label_visibility='hidden',
+        help="Describe the code you want to generate"
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 5, 10, 15", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input for testing your code")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. Expected output format", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output for testing")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the null pointer exception", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Specific instructions for debugging the code")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", label_visibility='collapsed', help="Name of the file to save code to")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added descriptive `help` tooltips and replaced generic `placeholder` values with actionable examples for several `st.text_area` and `st.text_input` fields (prompt, stdin, stdout, debug instructions, file name) in `script.py` which had their `label_visibility` set to `'hidden'` or `'collapsed'`.

🎯 Why: In Streamlit UI, hiding or collapsing labels removes essential context for users, particularly those relying on screen readers. Adding tooltips and clearer placeholders compensates for the missing visible labels, making the interface more intuitive and accessible without altering the visual layout.

📸 Before/After:
Before: `st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed')`
After: `st.text_input("Input (Stdin)", placeholder="e.g. 5, 10, 15", label_visibility='collapsed', help="Standard input for testing your code")`

♿ Accessibility: Improved context for assistive technologies by ensuring elements without visible labels still provide purpose and guidance via `help` tooltips and descriptive placeholders.

---
*PR created automatically by Jules for task [7026064960824225332](https://jules.google.com/task/7026064960824225332) started by @haseeb-heaven*