### PR TITLE
🎨 Palette: Add accessibility tooltips to hidden label inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-15 - Hidden/Collapsed Label Accessibility in Streamlit
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context, making them difficult for screen reader users to understand.
+**Action:** Always compensate by providing descriptive `help` tooltips and actionable `placeholder` examples to restore context.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Enter your prompt or requirements for code generation. This text is passed to the AI model."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. Test input data", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input (stdin) provided to the code during execution.")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. Expected output format", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output (stdout) to verify execution.")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the NullPointerException", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Specific instructions to guide the AI when fixing or debugging the code.")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. script.py", label_visibility='collapsed', help="Provide a file name (including extension) to save the generated code.")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added descriptive `help` tooltips and realistic, actionable `placeholder` examples to input fields in `script.py` (like standard input/output, debug instructions, and file name) that have `label_visibility` set to `hidden` or `collapsed`. Also logged this learning in the Palette journal.
🎯 Why: In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose their accessibility context. This makes them difficult for screen reader users to understand and can be confusing for general users if the previous placeholder text was redundant (e.g., placeholder="File name" for a File name input).
📸 Before/After: Before, inputs lacked `help` tooltips and had redundant placeholders. Now, they have clear tooltips explaining their purpose and actionable examples like "e.g. script.py".
♿ Accessibility: Improved accessibility for screen readers by providing context through tooltips that was previously lost due to hidden labels.

---
*PR created automatically by Jules for task [10812310421334355025](https://jules.google.com/task/10812310421334355025) started by @haseeb-heaven*