### PR TITLE
🎨 Palette: Add accessibility tooltips to hidden label inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2026-06-18 - Added accessibility tooltips to Streamlit inputs
+
+**Learning:** When using `label_visibility='collapsed'` or `'hidden'` in Streamlit, the inputs lose their accessibility context for screen readers.
+**Action:** Always provide descriptive `help` tooltips and actionable `placeholder` examples to compensate for the hidden labels and maintain accessibility.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        placeholder="e.g. Write a python function to calculate the factorial of a number." if 'code_prompt' not in st.session_state else "",
+        label_visibility='hidden',
+        help="Enter your prompt for code generation or completion."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. user_input = 'Hello World'", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input for the code execution")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. Expected output", label_visibility='collapsed',value=st.session_state.code_output, help="Standard output expected from the code execution")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the indentation error on line 5", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Instructions for fixing or debugging the code")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", label_visibility='collapsed', help="Name of the file to save the generated code")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What:** Added descriptive `help` tooltips and improved `placeholder` examples for inputs (`code_prompt`, `code_input`, `code_output`, `code_fix_instructions`, and `code_file`) that use `label_visibility='hidden'` or `'collapsed'`. Also updated the UX journal to log this finding.
🎯 **Why:** Streamlit inputs with hidden or collapsed labels lose their context for screen readers and can be confusing for general users. The added tooltips and rich placeholders restore that context gracefully while maintaining the clean UI design.
📸 **Before/After:** No visible changes to the primary layout; tooltips appear natively when hovering, and inputs show more context-aware placeholders.
♿ **Accessibility:** Re-established contextual information for previously unlabeled (visually hidden) interactive elements, making the application significantly more accessible.

---
*PR created automatically by Jules for task [16294617143864312307](https://jules.google.com/task/16294617143864312307) started by @haseeb-heaven*