### PR TITLE
🎨 Palette: Enhance accessibility for hidden labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-19 - Enhance accessibility for collapsed labels in Streamlit inputs
+**Learning:** In Streamlit UIs, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers and general usability.
+**Action:** Compensate by providing descriptive `help` tooltips and actionable `placeholder` examples for any hidden labels.

--- a/script.py
+++ b/script.py
@@ -263,16 +263,17 @@ def main():
         "Enter Prompt", 
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
-        placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        placeholder="Enter your prompt for code generation. E.g. 'Write a Python function to read a file.'",
+        label_visibility='hidden',
+        help="Provide a detailed description of the code you want to generate."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. Test input data...", label_visibility='collapsed',value=st.session_state.code_input, help="Standard input for your code execution")
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Expected output...", label_visibility='collapsed',value=st.session_state.code_output, help="Expected standard output for verification")
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the index out of bounds error...", label_visibility='collapsed',value=st.session_state.code_fix_instructions, help="Instructions for the AI to debug your code")
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", label_visibility='collapsed', help="Filename to save the generated code")
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added actionable `placeholder` examples and descriptive `help` tooltips to `st.text_input` and `st.text_area` fields that use `label_visibility='hidden'` or `'collapsed'` in `script.py`.

🎯 Why: In Streamlit, inputs with hidden or collapsed labels lose accessibility context. By utilizing placeholders as examples and tooltips as descriptive context, screen reader users and general users will understand the purpose of the inputs more clearly without cluttering the UI with labels.

📸 Before/After:
Before: `st.text_input` and `st.text_area` relying solely on redundant generic placeholders or lack of any context text if label is hidden.
After: Placeholders like "e.g. Test input data..." and "e.g. main.py" have been added, alongside tooltips providing context.

♿ Accessibility: Restores context for inputs lacking visual labels, aiding screen readers and keyboard navigation users with helpful native tooltip patterns.

---
*PR created automatically by Jules for task [12106789410270888716](https://jules.google.com/task/12106789410270888716) started by @haseeb-heaven*