### PR TITLE
🎨 Palette: Add accessible tooltips to inputs with hidden labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-20 - Streamlit Accessibility with Hidden Labels
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context for screen readers and can confuse users.
+**Action:** Always compensate by providing descriptive `help` tooltips and actionable `placeholder` examples.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
+        help="Type your natural language prompt here to generate code.",
         label_visibility='hidden'
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g., test input value for stdin", help="Standard input for the code execution", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g., expected output value", help="Expected standard output to verify against", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g., Fix the index out of bounds error", help="Instructions for the AI to debug the code", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g., main.py", help="Name of the file to save code as", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What:
Added descriptive `help` tooltips and actionable `placeholder` examples to Streamlit text inputs and text areas that utilize `label_visibility='collapsed'` or `'hidden'`.

🎯 Why:
When a Streamlit input has a hidden or collapsed label, it loses crucial context, making it less intuitive for general users and completely inaccessible for screen readers. By leveraging the built-in `help` parameter (which Streamlit renders as a tooltip/accessible description) and providing concrete `placeholder` examples, we restore this lost context without compromising the compact UI design.

📸 Before/After:
*   **Before:** Input fields like "Input (Stdin)", "Output (Stdout)", and "Debug instructions" had collapsed labels and generic placeholders, providing no context if hovered over or read by a screen reader.
*   **After:** These fields now feature clear example placeholders (e.g., "e.g., test input value for stdin") and helpful tooltips (e.g., "Standard input for the code execution") that appear on hover and are read by assistive technologies.

♿ Accessibility:
Significantly improves keyboard and screen reader accessibility by ensuring all input fields have an associated accessible description via the `help` attribute, compensating for the intentionally visually hidden labels. A journal entry was added to `.jules/palette.md` to document this Streamlit-specific pattern.

---
*PR created automatically by Jules for task [1393121052033946839](https://jules.google.com/task/1393121052033946839) started by @haseeb-heaven*