### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution vulnerability in eval()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-20 - Insecure use of eval() for state keys
+**Vulnerability:** The application used `eval()` to dynamically evaluate state keys like `'st.session_state.project'` from a dictionary.
+**Learning:** Using `eval()` to evaluate state keys is a security anti-pattern. It can lead to arbitrary code execution if inputs are user-controlled.
+**Prevention:** Never use `eval()` to dynamically check variables or keys. Always use safer alternatives like `st.session_state.get(key)`.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The Streamlit app was dynamically evaluating strings from a hard-coded mapping dictionary using the `eval()` function to resolve whether specific session state keys were populated (e.g., `'st.session_state.project'`). While not immediately exploitable via arbitrary user input in this explicit flow, `eval()` remains a critical security anti-pattern. If future modifications were to allow dictionary keys to be user-controlled, this would open the door to remote/arbitrary code execution (RCE).
🎯 **Impact:** Prevents potential arbitrary code execution vulnerabilities and resolves errors where `eval()` crashes ungracefully when Streamlit session state keys have not been populated yet.
🔧 **Fix:** Refactored the key/value data structure (in `script.py` around line 163) to map from literal keys (e.g., `'project'`) rather than full string properties. Replaced the list comprehension check to evaluate using the much safer `st.session_state.get(var)` approach.
✅ **Verification:** Verified syntax correctness by running `python3 -m py_compile script.py` and `PYTHONPATH=. pytest`. Both passed. I have also documented this learning regarding `eval()` vulnerabilities in the Sentinel Journal (`.jules/sentinel.md`).

---
*PR created automatically by Jules for task [8281030381419150664](https://jules.google.com/task/8281030381419150664) started by @haseeb-heaven*