### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Saving

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-21 - Path Traversal in File Saving and Uploads
+**Vulnerability:** User-provided file names in `save_code` and `save_uploaded_file_temp` were directly used in file operations, allowing path traversal (e.g., saving files outside the intended directory).
+**Learning:** We must never trust user-supplied filenames directly in filesystem operations, even for temporary files or within specific workflows.
+**Prevention:** Always use `os.path.basename()` to extract just the filename component from user input before joining paths or opening files.

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -296,6 +296,8 @@ class GeneralUtils:
                 logger.error("Error in code saving: Please enter a valid file name.")
                 return
             
+            # SECURITY: Sanitize file_name to prevent path traversal vulnerabilities
+            file_name = os.path.basename(file_name)
             file_extension = file_name.split(".")[-1]
             logger.info(f"Saving code to file: {file_name} with extension: {file_extension}")
             
@@ -412,7 +414,9 @@ class GeneralUtils:
             os.makedirs(temp_dir, exist_ok=True)
             
             logger.info(f"Saving uploaded file to {temp_dir}")
-            file_path = os.path.join(temp_dir, uploadedfile.name)
+            # SECURITY: Sanitize uploaded file name to prevent path traversal
+            safe_file_name = os.path.basename(uploadedfile.name)
+            file_path = os.path.join(temp_dir, safe_file_name)
             with open(file_path, "wb") as f:
                 f.write(uploadedfile.getbuffer())
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A path traversal vulnerability existed in `libs/general_utils.py` where user-provided file names in `save_code` and `save_uploaded_file_temp` were directly used in file operations (`os.path.join` and `open`).
🎯 Impact: This allowed malicious actors to potentially save or overwrite files outside the intended directories (e.g., by uploading a file named `../../sensitive_file.py`).
🔧 Fix: Added `os.path.basename()` to sanitize incoming filenames, stripping out directory structures and keeping only the file name itself. This breaks path traversal exploits while retaining intended functionality. Added Sentinel security comments. Updated `.jules/sentinel.md` journal with critical learning.
✅ Verification: 
- Ran `python3 -m py_compile libs/general_utils.py` with no syntax errors.
- Ran test suite with `PYTHONPATH=. pytest` (no tests failed/none exist).
- Code review requested and passed as Correct.

---
*PR created automatically by Jules for task [15515572937499290090](https://jules.google.com/task/15515572937499290090) started by @haseeb-heaven*