### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval() vulnerability in session state checking

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-22 - Fix eval() anti-pattern for session state checking
+**Vulnerability:** Code used `eval()` to dynamically check values in Streamlit's `session_state` based on string keys, which is a known anti-pattern that can lead to Remote Code Execution (RCE) if keys are ever user-controlled.
+**Learning:** Even if the strings are currently hardcoded, using `eval()` to resolve object properties or dictionary items is a dangerous habit that breaks the "Trust nothing" principle.
+**Prevention:** Always use safe dictionary access methods like `dict.get(key)` or `st.session_state.get(key)` instead of dynamically evaluating strings.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Code used `eval()` to dynamically check values in Streamlit's `session_state` based on string keys, leading to potential Remote Code Execution (RCE) if those keys are ever user-controlled.
🎯 Impact: Arbitrary code execution if string evaluation inputs become controlled by an attacker.
🔧 Fix: Replaced the `eval()` usage with safe dictionary access via `st.session_state.get(var)` and updated dictionary keys appropriately.
✅ Verification: Ran Python syntax checks with `py_compile` and manually verified file logic. Recorded the `eval()` anti-pattern in the Sentinel journal `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18352072033968938586](https://jules.google.com/task/18352072033968938586) started by @haseeb-heaven*