### PR TITLE
🎨 Palette: Add context to hidden inputs via tooltips and placeholders

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-23 - Accessibility Context in Streamlit
+**Learning:** In Streamlit applications, when inputs use label_visibility='collapsed' or 'hidden' (to save space or for aesthetic reasons), the input fields lose their accessibility context for screen readers and can become confusing for all users.
+**Action:** Compensate for hidden labels by always providing descriptive `help` tooltips and actionable `placeholder` examples to maintain context and accessibility.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Enter the detailed instruction or code prompt for the AI model to process."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g., John Doe (Stdin data)", help="Provide standard input data for testing the executed code.", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g., Hello John Doe (Expected Stdout)", help="Expected standard output to test against the executed code.", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g., Fix the null pointer exception", help="Provide specific instructions for the AI to debug or fix the generated code.", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g., script", help="Enter the filename (without extension) to save the generated code.", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 **What**: Added `help` tooltips and descriptive `placeholder` examples to text input fields in the main Streamlit interface where labels were hidden or collapsed.
🎯 **Why**: When Streamlit input labels are visually hidden (`label_visibility='collapsed'` or `'hidden'`), they lose accessibility context for screen readers and can become confusing for all users.
📸 **Before/After**: Before, the text inputs only had generic placeholders (e.g., "Input (Stdin)") and no tooltips. Now, they have contextual placeholders (e.g., "e.g., John Doe (Stdin data)") and descriptive tooltips explaining their exact purpose.
♿ **Accessibility**: Restores crucial context for screen readers and assists visual users by explaining the expected input format without cluttering the UI with permanent labels.

---
*PR created automatically by Jules for task [9251013911885286853](https://jules.google.com/task/9251013911885286853) started by @haseeb-heaven*