### PR TITLE
🛡️ Sentinel: [HIGH] Fix Arbitrary Code Execution Risk (eval)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-23 - Remove insecure eval() for session state checking
+**Vulnerability:** Arbitrary code execution risk from using eval() on dictionary keys to check Streamlit session state properties.
+**Learning:** Using eval() to dynamically evaluate code strings or check dictionary values is a security anti-pattern that can lead to arbitrary code execution if inputs are not tightly controlled.
+**Prevention:** Use safer alternatives like dict.get(key) or st.session_state.get(key) to securely access dynamic state variables.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
## 🚨 Severity
HIGH

## 💡 Vulnerability
The codebase used `eval()` to dynamically evaluate strings representing dictionary keys (like `'st.session_state.project'`) to check if they were set. While not immediately exploitable via external user input in this specific location, using `eval()` for state checking is a dangerous anti-pattern that can lead to arbitrary code execution if inputs are ever manipulated or refactored.

## 🎯 Impact
If an attacker could control or inject content into the evaluated strings, they could execute arbitrary Python code within the application's context, leading to full system compromise or data exfiltration.

## 🔧 Fix
- Modified `script.py` to use `st.session_state.get(key)` instead of `eval(key)`.
- Updated the dictionary keys to map directly to the session state property names (e.g., `'project'` instead of `'st.session_state.project'`).
- Documented the fix in the `.jules/sentinel.md` journal to prevent this anti-pattern in the future.

## ✅ Verification
1. Run `python3 -m py_compile script.py` to ensure syntax is correct.
2. Verified that the fallback logic for checking missing Vertex AI settings operates identically without using `eval`.

---
*PR created automatically by Jules for task [418254857798967111](https://jules.google.com/task/418254857798967111) started by @haseeb-heaven*