### PR TITLE
🎨 Palette: Add `help` and examples to inputs with hidden labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-24 - Compensate for hidden labels in Streamlit
+**Learning:** In Streamlit applications, using `label_visibility='collapsed'` or `'hidden'` removes important context for screen readers and users.
+**Action:** Always compensate for hidden labels by providing descriptive `help` tooltips and actionable `placeholder` examples.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
-        label_visibility='hidden'
+        label_visibility='hidden',
+        help="Type the instructions or description of the code you want the AI to generate."
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g. 5, 10 or test_string", help="Standard input to provide to the code when it runs.", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g. Expected output 15", help="Expected standard output to verify the code against.", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g. Fix the NullPointerException on line 42", help="Provide specific instructions or error messages to help the AI debug the code.", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g. main.py", help="Enter the file name including extension to save the generated code.", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What: Added descriptive `help` tooltips and actionable `placeholder` examples to input fields where Streamlit `label_visibility` is configured as 'collapsed' or 'hidden' (e.g. Code Prompt, Input, Output, Debug Instructions, File Name).

🎯 Why: In Streamlit applications, setting `label_visibility='collapsed'` or `'hidden'` removes important context for screen readers and users. Providing tooltips and explicit examples restores context while maintaining the desired layout.

📸 Before/After: The inputs previously had no tooltips and generic placeholders like "File name" or "Input (Stdin)". Now they display actionable examples like "e.g. main.py" and offer descriptive help icons on hover.

♿ Accessibility: Specifically addresses the loss of screen reader context caused by hidden Streamlit labels.

---
*PR created automatically by Jules for task [3559259928533320100](https://jules.google.com/task/3559259928533320100) started by @haseeb-heaven*