### PR TITLE
🛡️ Sentinel: [HIGH] Fix eval() vulnerability in script.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-25 - Removed unsafe eval() in script.py
+**Vulnerability:** The application used `eval()` to check if variables in `st.session_state` were set, which could lead to arbitrary code execution if user input reaches those variables.
+**Learning:** Using `eval()` to dynamically access dictionary or object properties is a dangerous anti-pattern.
+**Prevention:** Always use safe access methods like `dict.get(key)` or `getattr(obj, key)` instead of dynamically evaluating code strings.

--- a/script.py
+++ b/script.py
@@ -160,15 +160,15 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping session state keys
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
-                        # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        # Use a list comprehension to filter out the unset items using st.session_state.get()
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The application used `eval()` to dynamically evaluate strings representing variables in `st.session_state` to check if they were set. If user input or external data ever flowed into these strings, it could lead to Arbitrary Code Execution (RCE).
**🎯 Impact:** Using `eval()` is a known security anti-pattern. While the currently evaluated strings were hardcoded keys, relying on `eval()` creates a brittle, insecure pattern that future developers might unknowingly exploit.
**🔧 Fix:** Replaced `eval(var)` with `st.session_state.get(key)`, and updated the mapping dictionary to store the keys directly instead of strings of code. Added a journal entry explaining the dangers of `eval()` in `.jules/sentinel.md`.
**✅ Verification:**
- Ran `python3 -m py_compile script.py` to ensure correct syntax.
- Confirmed the `.jules/sentinel.md` journal was appended correctly.
- Reviewed the code changes for correctness and security best practices.

---
*PR created automatically by Jules for task [6671815994451747882](https://jules.google.com/task/6671815994451747882) started by @haseeb-heaven*