### PR TITLE
🎨 Palette: Improve accessibility context for hidden Streamlit labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Improve accessibility of hidden and collapsed labels in Streamlit
+**Learning:** In Streamlit UI, inputs using `label_visibility='collapsed'` or `'hidden'` lose accessibility context because screen readers lack the label text.
+**Action:** Compensate for hidden/collapsed labels by consistently providing descriptive `help` tooltips and actionable `placeholder` examples so context is retained.

--- a/script.py
+++ b/script.py
@@ -264,15 +264,16 @@ def main():
         value=st.session_state.code_prompt if 'code_prompt' in st.session_state else "",
         height=130, 
         placeholder="Enter your prompt for code generation." if 'code_prompt' not in st.session_state else "", 
+        help="Describe the code you want to generate",
         label_visibility='hidden'
     )
 
     # Settings for input and output options.
     with st.expander("Input Options"):
         with st.container():
-            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="Input (Stdin)", label_visibility='collapsed',value=st.session_state.code_input)
-            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="Output (Stdout)", label_visibility='collapsed',value=st.session_state.code_output)
-            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="Debug instructions", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
+            st.session_state.code_input = st.text_input("Input (Stdin)", placeholder="e.g., test input values", help="Standard input for the code execution", label_visibility='collapsed',value=st.session_state.code_input)
+            st.session_state.code_output = st.text_input("Output (Stdout)", placeholder="e.g., expected output", help="Expected standard output for verification", label_visibility='collapsed',value=st.session_state.code_output)
+            st.session_state.code_fix_instructions = st.text_input("Debug instructions", placeholder="e.g., fix the off-by-one error", help="Instructions for the AI to debug the code", label_visibility='collapsed',value=st.session_state.code_fix_instructions)
 
     # Set the input and output to None if the input and output is empty
     if st.session_state.code_input and st.session_state.code_output: 
@@ -294,7 +295,7 @@ def main():
 
         # Input Box (for entering the file name) in the first column
         with file_name_col:
-            code_file = st.text_input("File name", value="", placeholder="File name", label_visibility='collapsed')
+            code_file = st.text_input("File name", value="", placeholder="e.g., script.py", help="File name to save the generated code", label_visibility='collapsed')
 
         # Save Code button in the second column
         with save_code_col:


### PR DESCRIPTION
💡 What:
Added descriptive `help` tooltips and actionable `placeholder` examples to several Streamlit inputs (`code_prompt`, `code_input`, `code_output`, `code_fix_instructions`, and `code_file`) that use `label_visibility='hidden'` or `'collapsed'`.

🎯 Why:
In Streamlit, hiding or collapsing labels completely removes the text element, which severely degrades context for all users but specifically breaks accessibility for screen reader users since the input lacks a reachable accessible name. Adding tooltips and clear placeholder text restores this context without breaking the UI layout.

📸 Before/After:
Before: The code prompt text area and debug/file name input options lacked tooltips and had generic placeholders. Screen readers had no context for them.
After: Each field now has specific example placeholder strings (e.g., "e.g., test input values") and accessible `help` text acting as a tooltip providing intent (e.g., "Standard input for the code execution").

♿ Accessibility:
Significantly improves context for screen readers parsing inputs without explicitly visible label tags.

Added a critical learning journal entry in `.jules/palette.md` for this standard Streamlit UI pattern constraint.

---
*PR created automatically by Jules for task [1635082655618858977](https://jules.google.com/task/1635082655618858977) started by @haseeb-heaven*