### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix `eval()` vulnerability in session state check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-26 - Prevent eval() in Session State Checks
+**Vulnerability:** Use of eval() to dynamically check variable values (st.session_state).
+**Learning:** Developers used eval() as a shortcut to evaluate hardcoded string variables. While not immediately exploitable via user input here, it establishes a dangerous pattern that can lead to arbitrary code execution if user input reaches the eval context.
+**Prevention:** Never use eval() to check dictionary or session state values. Use safer alternatives like st.session_state.get(key).

--- a/script.py
+++ b/script.py
@@ -160,15 +160,16 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping session state keys to their names
+                        # Security: Avoid eval() for checking values, use st.session_state.get() instead
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The codebase used `eval()` to dynamically check if strings representing variables (e.g., `'st.session_state.project'`) evaluated to a truthy value.
🎯 Impact: While not immediately exploitable by direct user input in this specific context, using `eval()` establishes a dangerous pattern that can lead to arbitrary code execution if the variables involved are ever influenced by user input.
🔧 Fix: Replaced the `eval()` usage with standard dictionary access using `st.session_state.get(key)`. Added a security journal entry to document this learning.
✅ Verification: Verified syntax with `python3 -m py_compile script.py` and manually checked that `.jules/sentinel.md` correctly logged the vulnerability and prevention strategy.

---
*PR created automatically by Jules for task [4006655642125894217](https://jules.google.com/task/4006655642125894217) started by @haseeb-heaven*