### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Traversal in Code Saving

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-27 - Prevent Path Traversal in Code Saving
+**Vulnerability:** The `save_code` method in `libs/general_utils.py` blindly trusted the user-provided `file_name` and used string concatenation to create a file path (`f"{file_extension}/{file_name}"`). This allowed path traversal (e.g., passing `../../../etc/passwd`).
+**Learning:** Always sanitize user-provided filenames before using them in file system operations.
+**Prevention:** Use `os.path.basename()` to extract only the final filename component and `os.path.join()` to construct safe paths, preventing directory traversal attacks.

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -296,6 +296,9 @@ class GeneralUtils:
                 logger.error("Error in code saving: Please enter a valid file name.")
                 return
             
+            # Sanitize file name to prevent path traversal
+            file_name = os.path.basename(file_name)
+
             file_extension = file_name.split(".")[-1]
             logger.info(f"Saving code to file: {file_name} with extension: {file_extension}")
             
@@ -310,7 +313,7 @@ class GeneralUtils:
                 logger.error("Error in code saving: Generated code is empty.")
                 return
             
-            with open(f"{file_extension}/{file_name}", "w") as file:
+            with open(os.path.join(file_extension, file_name), "w") as file:
                 file.write(st.session_state.generated_code)
             
             st.toast(f"Code saved to file {file_name}", icon="✅")


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** The `save_code` method in `libs/general_utils.py` blindly trusted user input for `file_name` and used string concatenation (`f"{file_extension}/{file_name}"`) to construct the file path. This created a path traversal vulnerability (e.g. providing `../../../etc/passwd` as the filename).
**🎯 Impact:** A malicious user could write arbitrary files to unauthorized locations on the server file system.
**🔧 Fix:** Sanitized the `file_name` variable using `os.path.basename()` before utilizing it in any file system operations and replaced the string concatenation with `os.path.join(file_extension, file_name)`.
**✅ Verification:** Ran `python3 -m py_compile libs/general_utils.py` and `PYTHONPATH=. pytest` to ensure no syntax errors or regressions were introduced.
Also maintained the security journal documenting this learning at `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15528867495642309796](https://jules.google.com/task/15528867495642309796) started by @haseeb-heaven*