### PR TITLE
🛡️ Sentinel: [HIGH] Fix eval() Security Anti-pattern

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-30 - Fix eval() Security Anti-pattern
+**Vulnerability:** Use of `eval()` to dynamically evaluate strings representing `st.session_state` attributes in `script.py`.
+**Learning:** Using `eval()` for state checks is a dangerous security anti-pattern that can lead to arbitrary code execution if inputs are influenced by user data.
+**Prevention:** Access dictionaries or state objects directly using safe methods like `st.session_state.get(key)` instead of evaluating code strings.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Used `eval()` to dynamically evaluate strings representing `st.session_state` attributes in `script.py`. This is a dangerous security anti-pattern.
🎯 Impact: While the strings were currently hardcoded, using `eval()` for state checks can lead to arbitrary code execution if inputs ever become influenced by user data.
🔧 Fix: Replaced `eval(var)` with direct, safe dictionary lookups using `st.session_state.get(key)`. Updated dictionary mapping to match keys instead of string literals.
✅ Verification: Verified syntax using `python3 -m py_compile script.py`. Verified diff locally. Added a Sentinel journal entry documenting the pattern.

---
*PR created automatically by Jules for task [3257224732281808176](https://jules.google.com/task/3257224732281808176) started by @haseeb-heaven*