### PR TITLE
🎨 Palette: Add loading spinners for long-running operations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-03 - Added visual feedback for long-running operations
+**Learning:** Users lack visibility during long-running operations like AI code generation or execution, leading to uncertainty about the app's state.
+**Action:** Wrap such long-running operations (e.g., API calls, heavy computations) in a `with st.spinner("..."): ` block in Streamlit to provide immediate and clear visual feedback.

--- a/script.py
+++ b/script.py
@@ -309,57 +309,58 @@ def main():
             generate_submitted = st.form_submit_button(button_label)
             
             if generate_submitted:
-                if st.session_state.ai_option == "Open AI":
-                    if st.session_state.openai_langchain:
-                        st.session_state.generated_code = st.session_state.openai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                    else:# Reinitialize the chain
-                        if api_key == None:
-                            st.toast("Open AI API key is not initialized.", icon="❌")
-                            logger.error("Open AI API key is not initialized.")
-                        else:
-                            st.session_state.openai_langchain = OpenAILangChain(api_key,st.session_state.code_language,st.session_state["openai"]["temperature"],st.session_state["openai"]["max_tokens"],st.session_state["openai"]["model_name"])
+                with st.spinner("Generating code..."):
+                    if st.session_state.ai_option == "Open AI":
+                        if st.session_state.openai_langchain:
                             st.session_state.generated_code = st.session_state.openai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                elif st.session_state.ai_option == "Vertex AI":
-                    if st.session_state.vertexai_langchain:
-                        if not st.session_state.vertex_ai_loaded:
-                            st.toast("Vetex AI is not initialized.", icon="❌")
-                            logger.error("Vetex AI is not initialized.")
-                            return
-                        if st.session_state["vertexai"]["model_name"] == "code-bison":
+                        else:# Reinitialize the chain
+                            if api_key == None:
+                                st.toast("Open AI API key is not initialized.", icon="❌")
+                                logger.error("Open AI API key is not initialized.")
+                            else:
+                                st.session_state.openai_langchain = OpenAILangChain(api_key,st.session_state.code_language,st.session_state["openai"]["temperature"],st.session_state["openai"]["max_tokens"],st.session_state["openai"]["model_name"])
+                                st.session_state.generated_code = st.session_state.openai_langchain.generate_code(st.session_state.code_prompt, code_language)
+                    elif st.session_state.ai_option == "Vertex AI":
+                        if st.session_state.vertexai_langchain:
+                            if not st.session_state.vertex_ai_loaded:
+                                st.toast("Vetex AI is not initialized.", icon="❌")
+                                logger.error("Vetex AI is not initialized.")
+                                return
+                            if st.session_state["vertexai"]["model_name"] == "code-bison":
+                                st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code(st.session_state.code_prompt, code_language)
+                            else:
+                                st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code_completion(st.session_state.code_prompt, code_language)
+                        else: # Reinitalize the chain
+                            st.session_state.vertexai_langchain= VertexAILangChain(project=st.session_state.project, location=st.session_state.region, model_name=st.session_state["vertexai"]["model_name"], max_tokens=st.session_state["vertexai"]["max_tokens"], temperature=st.session_state["vertexai"]["temperature"], credentials_file_path=credentials_file_path)
+                            st.session_state.vertex_ai_loaded = st.session_state.vertexai_langchain.load_model(st.session_state["vertexai"]["model_name"],st.session_state["vertexai"]["max_tokens"],st.session_state["vertexai"]["temperature"])
                             st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                        else:
-                            st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code_completion(st.session_state.code_prompt, code_language)
-                    else: # Reinitalize the chain
-                        st.session_state.vertexai_langchain= VertexAILangChain(project=st.session_state.project, location=st.session_state.region, model_name=st.session_state["vertexai"]["model_name"], max_tokens=st.session_state["vertexai"]["max_tokens"], temperature=st.session_state["vertexai"]["temperature"], credentials_file_path=credentials_file_path)
-                        st.session_state.vertex_ai_loaded = st.session_state.vertexai_langchain.load_model(st.session_state["vertexai"]["model_name"],st.session_state["vertexai"]["max_tokens"],st.session_state["vertexai"]["temperature"])
-                        st.session_state.generated_code = st.session_state.vertexai_langchain.generate_code(st.session_state.code_prompt, code_language)
-                
-                elif st.session_state.ai_option == "Palm AI":
-                    if st.session_state.palm_langchain:
-                        st.session_state.generated_code = st.session_state.palm_langchain.generate_code(st.session_state.code_prompt, code_language)
-                    else:# Reinitialize the chain
-                        if api_key == None:
-                            st.toast("Palm AI API key is not initialized.", icon="❌")
-                            logger.error("Palm AI API key is not initialized.")
-                        else:
-                            st.session_state.palm_langchain = PalmAI(api_key, model=st.session_state["palm"]["model_name"], temperature=st.session_state["palm"]["temperature"], max_output_tokens=st.session_state["palm"]["max_tokens"])
+
+                    elif st.session_state.ai_option == "Palm AI":
+                        if st.session_state.palm_langchain:
                             st.session_state.generated_code = st.session_state.palm_langchain.generate_code(st.session_state.code_prompt, code_language)
-            
-                elif st.session_state.ai_option == "Gemini AI":
-                    if st.session_state.gemini_langchain:
-                        st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
-                    else:# Reinitialize the chain
-                        if api_key == None:
-                            st.toast("Gemini AI API key is not initialized.", icon="❌")
-                            logger.error("Gemini AI API key is not initialized.")
-                        else:
-                            st.session_state.gemini_langchain = GeminiAI(api_key, model=st.session_state["gemini"]["model_name"], temperature=st.session_state["gemini"]["temperature"], max_output_tokens=st.session_state["gemini"]["max_tokens"])
-                            st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
+                        else:# Reinitialize the chain
+                            if api_key == None:
+                                st.toast("Palm AI API key is not initialized.", icon="❌")
+                                logger.error("Palm AI API key is not initialized.")
+                            else:
+                                st.session_state.palm_langchain = PalmAI(api_key, model=st.session_state["palm"]["model_name"], temperature=st.session_state["palm"]["temperature"], max_output_tokens=st.session_state["palm"]["max_tokens"])
+                                st.session_state.generated_code = st.session_state.palm_langchain.generate_code(st.session_state.code_prompt, code_language)
                 
-                else:
-                    st.toast(f"Please select a valid AI option selected '{st.session_state.ai_option}' option", icon="❌")
-                    st.session_state.generated_code = ""
-                    logger.error(f"Please select a valid AI option selected '{st.session_state.ai_option}' option")
+                    elif st.session_state.ai_option == "Gemini AI":
+                        if st.session_state.gemini_langchain:
+                            st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
+                        else:# Reinitialize the chain
+                            if api_key == None:
+                                st.toast("Gemini AI API key is not initialized.", icon="❌")
+                                logger.error("Gemini AI API key is not initialized.")
+                            else:
+                                st.session_state.gemini_langchain = GeminiAI(api_key, model=st.session_state["gemini"]["model_name"], temperature=st.session_state["gemini"]["temperature"], max_output_tokens=st.session_state["gemini"]["max_tokens"])
+                                st.session_state.generated_code = st.session_state.gemini_langchain.generate_code(st.session_state.code_prompt, code_language)
+
+                    else:
+                        st.toast(f"Please select a valid AI option selected '{st.session_state.ai_option}' option", icon="❌")
+                        st.session_state.generated_code = ""
+                        logger.error(f"Please select a valid AI option selected '{st.session_state.ai_option}' option")
 
         # Debug Code button in the fourth column
         with debug_code_col:
@@ -383,7 +384,8 @@ def main():
                     logger.info("Setting Stderr from input to Debug instructions.")
                     
                 logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
+                with st.spinner("Fixing code..."):
+                    st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
         # Debug Code button in the fourth column
         with convert_code_col:
@@ -399,7 +401,8 @@ def main():
                     ai_llm_selected = st.session_state.openai_langchain
                     
                 logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
+                with st.spinner("Converting code..."):
+                    st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
         # Run Code button in the fourth column
@@ -410,7 +413,8 @@ def main():
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
     
                 if privacy_accepted:
-                    st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
+                    with st.spinner("Executing code..."):
+                        st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
                 else:
                     st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
                     logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")


### PR DESCRIPTION
## 💡 What
Added visual loading spinners (`st.spinner`) to wrap the long-running LLM API calls and execution tasks in the main Streamlit application (`script.py`).

## 🎯 Why
Long-running operations such as generating code, fixing code, converting code, and compiling/executing code previously had no visual feedback. Users could click a button and be left wondering if the application was processing their request or had frozen, leading to a poor user experience. Adding spinners gives immediate visual confirmation that the system is working.

## 📸 Before/After
**Before:** Clicking "Generate", "Debug", "Convert", or "Execute" provided no immediate visual state change until the operation completed or failed.
**After:** Clicking any of these buttons immediately renders a spinner with a context-appropriate message (e.g., "Generating code...", "Fixing code...") while the operation is pending.

## ♿ Accessibility
This improves cognitive accessibility by preventing user confusion and anxiety caused by non-responsive interfaces during asynchronous tasks.

*Journal updated at `.jules/palette.md`*

---
*PR created automatically by Jules for task [1570873879505751538](https://jules.google.com/task/1570873879505751538) started by @haseeb-heaven*