### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval() arbitrary code execution vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-07 - Fix eval() Vulnerability in State Checks
+**Vulnerability:** Arbitrary code execution via the use of `eval()` to dynamically evaluate strings representing `st.session_state` keys in `script.py`.
+**Learning:** Using `eval()` is a critical security risk and a known anti-pattern. While the inputs in this specific instance were hardcoded dictionary keys, using `eval()` sets a dangerous precedent and can easily lead to arbitrary code execution if user inputs or external data are ever introduced into the evaluation flow.
+**Prevention:** Never use `eval()` for dynamic string evaluation. Instead, directly access state values using safer alternatives like `st.session_state.get(key)`.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `script.py` file used `eval()` to dynamically evaluate strings representing `st.session_state` keys when checking if Vertex AI settings were provided. This is a critical security anti-pattern that can lead to arbitrary code execution.
🎯 Impact: While the current inputs to `eval()` were hardcoded dictionary keys, maintaining this pattern sets a dangerous precedent. If the input source were ever changed to include user-controlled data or external input, it would allow a malicious actor to execute arbitrary Python code on the server, compromising the entire application and host environment.
🔧 Fix: Replaced the use of `eval(var)` with direct dictionary/state lookups using `st.session_state.get(var)`, changing the hardcoded strings from `'st.session_state.project'` to just `'project'`. This safely retrieves the state values without invoking the Python interpreter dynamically.
✅ Verification: Ran `python3 -m py_compile script.py` to verify no syntax errors were introduced. The fix is localized and does not affect the logical check for missing settings.

---
*PR created automatically by Jules for task [7461137278302894985](https://jules.google.com/task/7461137278302894985) started by @haseeb-heaven*