### PR TITLE
🎨 Palette: Add visual feedback for long-running operations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Adding visual feedback for long-running operations
+**Learning:** In Streamlit applications, long-running operations like AI generation or API calls can make the app appear unresponsive.
+**Action:** Wrap long-running operations in a `with st.spinner("..."):` block to provide clear, immediate visual feedback to the user. Keep these blocks localized to the specific action rather than wrapping large conditional branches to maintain clean code structure.

--- a/script.py
+++ b/script.py
@@ -383,7 +383,8 @@ def main():
                     logger.info("Setting Stderr from input to Debug instructions.")
                     
                 logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
+                with st.spinner('Debugging code...'):
+                    st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
         # Debug Code button in the fourth column
         with convert_code_col:
@@ -399,7 +400,8 @@ def main():
                     ai_llm_selected = st.session_state.openai_langchain
                     
                 logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
+                with st.spinner('Converting code...'):
+                    st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
         # Run Code button in the fourth column
@@ -410,7 +412,8 @@ def main():
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
     
                 if privacy_accepted:
-                    st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
+                    with st.spinner('Executing code...'):
+                        st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
                 else:
                     st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
                     logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")


### PR DESCRIPTION
💡 What
Added `with st.spinner('...')` blocks around the "Debug", "Convert", and "Execute" code operations in `script.py`. Also created a `.jules/palette.md` UX journal entry to document the learning.

🎯 Why
Long-running operations like AI code generation or API calls can make the Streamlit application appear unresponsive to users. Wrapping these localized execution blocks in `st.spinner()` provides clear, immediate visual feedback that a background process is ongoing.

📸 Before/After
- Before: Clicking "Debug", "Convert", or "Execute" provided no immediate visual feedback while the background process ran.
- After: Clicking these buttons now immediately displays a localized spinner with a descriptive message (e.g., "Debugging code...", "Converting code..."), reassuring the user.

♿ Accessibility
Improves usability and perceived performance by providing explicit visual status indicators for asynchronous tasks.

---
*PR created automatically by Jules for task [10301741007617560612](https://jules.google.com/task/10301741007617560612) started by @haseeb-heaven*