### PR TITLE
🎨 Palette: Add loading spinners for background tasks

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-15 - Adding Immediate Loading States
+**Learning:** Streamlit applications lack visual feedback during long-running background tasks like AI generation or executing code, leaving users uncertain if the app is responsive or hung.
+**Action:** Wrap targeted, long-running execution statements (like API calls or compilations) in `with st.spinner("..."): ` blocks to provide immediate visual loading states, keeping changes under 50 lines by wrapping localized blocks instead of large conditional branches.

--- a/script.py
+++ b/script.py
@@ -383,7 +383,8 @@ def main():
                     logger.info("Setting Stderr from input to Debug instructions.")
                     
                 logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
+                with st.spinner("Debugging code..."):
+                    st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
         # Debug Code button in the fourth column
         with convert_code_col:
@@ -399,7 +400,8 @@ def main():
                     ai_llm_selected = st.session_state.openai_langchain
                     
                 logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
+                with st.spinner("Converting code..."):
+                    st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
         # Run Code button in the fourth column
@@ -410,7 +412,8 @@ def main():
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
     
                 if privacy_accepted:
-                    st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
+                    with st.spinner("Executing code..."):
+                        st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
                 else:
                     st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
                     logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")


### PR DESCRIPTION
💡 What
Wrapped long-running Streamlit actions (Debug, Convert, Execute) in `st.spinner` context blocks.

🎯 Why
Streamlit execution blocks the UI thread synchronously. Without visual indicators during long operations (like AI API calls or code compilation), the app feels unresponsive and users might assume it has frozen.

📸 Before/After
Before: Clicking Debug/Convert/Execute showed no immediate visual change until the result rendered.
After: A native Streamlit loading spinner immediately appears while the action is processing.

♿ Accessibility
Improves system state visibility (WCAG 3.2.2 Predictable) by letting screen readers and sighted users know that a background task is processing and the system has not stalled.

---
*PR created automatically by Jules for task [9035698007008304474](https://jules.google.com/task/9035698007008304474) started by @haseeb-heaven*