### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution risk from eval()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-18 - Remove eval() usage in Streamlit app
+**Vulnerability:** The `eval()` function is used in `script.py` to dynamically evaluate strings representing Streamlit session state variables (e.g., `'st.session_state.project'`).
+**Learning:** Using `eval()` on strings is a security anti-pattern as it can lead to arbitrary code execution if the input strings are ever influenced by user input, and it's unnecessary here since we can access the session state dictionary directly.
+**Prevention:** Always access `st.session_state` values using dictionary keys or attribute access (e.g., `st.session_state.get(key)`) instead of dynamically evaluating strings.

--- a/script.py
+++ b/script.py
@@ -160,15 +160,15 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping session state keys to names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `eval()` function was being used to dynamically evaluate strings representing Streamlit session state variables. This is a dangerous anti-pattern that can lead to arbitrary code execution if the evaluated strings ever become user-controllable.
🎯 Impact: While currently evaluating hardcoded strings, leaving `eval()` in the codebase sets a dangerous precedent and introduces risk if the logic is ever modified to accept dynamic input.
🔧 Fix: Replaced the `eval()` call with safe dictionary access using `st.session_state.get(key)`. The variable map was also updated to map string keys to string display names, rather than string code literals.
✅ Verification: Ran syntax checks using `python3 -m py_compile script.py` and ensured there are no leftover test files.

---
*PR created automatically by Jules for task [14267931293759244696](https://jules.google.com/task/14267931293759244696) started by @haseeb-heaven*