### PR TITLE
🎨 Palette: Add loading spinners to async operations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2026-07-18 - Adding Spinners for Async Actions in Streamlit
+
+**Learning:** Streamlit UI components running synchronous or long-running async tasks block the interface. Without a visual indicator, users may assume the application is unresponsive. Wrapping the execution block directly (e.g. `with st.spinner("..."): `) instead of the whole button conditional branch is a cleaner UX fix that maintains code organization under 50 lines.
+**Action:** Always add `st.spinner()` (or equivalent loading states) when initiating long-running code generation or execution actions in Streamlit to improve perceived performance and keep the user informed.

--- a/script.py
+++ b/script.py
@@ -383,7 +383,8 @@ def main():
                     logger.info("Setting Stderr from input to Debug instructions.")
                     
                 logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
+                with st.spinner("Debugging code..."):
+                    st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
         # Debug Code button in the fourth column
         with convert_code_col:
@@ -399,7 +400,8 @@ def main():
                     ai_llm_selected = st.session_state.openai_langchain
                     
                 logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
+                with st.spinner("Converting code..."):
+                    st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
         # Run Code button in the fourth column
@@ -410,7 +412,8 @@ def main():
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
     
                 if privacy_accepted:
-                    st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
+                    with st.spinner("Executing code..."):
+                        st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
                 else:
                     st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
                     logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")


### PR DESCRIPTION
💡 What: Added `st.spinner()` visual feedback states to the "Debug", "Convert", and "Execute" operations in the main UI.
🎯 Why: These operations execute code or make API calls to LLMs, which can take several seconds. Without a loading indicator, users might think the application has frozen or click the button multiple times.
📸 Before/After: Visual changes add a loading spinner next to the "Running" state for these operations.
♿ Accessibility: Improves perceived performance and provides clear state communication to users.

---
*PR created automatically by Jules for task [13612211194188924713](https://jules.google.com/task/13612211194188924713) started by @haseeb-heaven*