### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-19 - Remove eval() to prevent arbitrary code execution
+**Vulnerability:** The `eval()` function was used to dynamically evaluate strings from a dictionary mapping session state variables (`eval(var)`). While the current inputs were static strings, using `eval()` is a dangerous anti-pattern that can lead to arbitrary code execution if user inputs ever reach that code path.
+**Learning:** Never use `eval()` to check or access dictionary values or object properties, as it executes the string as Python code, creating severe security risks.
+**Prevention:** Use safer alternatives like direct dictionary lookups (e.g., `dict.get(key)` or `st.session_state.get(key)`) to access values dynamically without executing code.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
## 🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution vulnerability

### 🚨 Severity
CRITICAL

### 💡 Vulnerability
The `eval()` function was being used to dynamically parse strings representing Streamlit session state properties (`eval(var)`) in `script.py`. While the inputs (`items` dictionary keys) were static at this location, using `eval()` is a highly dangerous Python anti-pattern that can easily lead to arbitrary code execution if it's ever accidentally exposed to user-provided or external inputs.

### 🎯 Impact
If user inputs, uploaded file names, or external configuration sources ever reached the `eval()` path, an attacker could inject arbitrary Python code, resulting in complete system compromise (RCE).

### 🔧 Fix
1. Updated the keys in the `items` dictionary to directly match the session state variable names (e.g., `'st.session_state.project'` -> `'project'`).
2. Replaced the dangerous `eval(var)` check with the standard and safe `st.session_state.get(var)` dictionary lookup method.
3. Created a Sentinel journal entry documenting the learning about `eval()`.

### ✅ Verification
1. Syntax validation: `python3 -m py_compile script.py` passes without errors.
2. The logic for filtering missing settings in the Vertex AI setup block remains functionally identical, correctly identifying unset required settings.

---
*PR created automatically by Jules for task [11967399423333897598](https://jules.google.com/task/11967399423333897598) started by @haseeb-heaven*