### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution risk by removing eval()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-20 - Remove eval() for Session State Checks
+**Vulnerability:** Using `eval()` to evaluate variable names dynamically from `st.session_state`.
+**Learning:** Using `eval()` is a critical security vulnerability as it allows arbitrary code execution if user input ever makes its way into the evaluated strings.
+**Prevention:** Use `st.session_state.get(key)` directly with the keys rather than passing string representations of variable access to `eval()`.

--- a/script.py
+++ b/script.py
@@ -160,15 +160,15 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping session state keys to friendly names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Used `eval()` to dynamically evaluate variable names from user-accessible Streamlit session state.
🎯 Impact: High risk of arbitrary code execution if unsanitized user input reaches the evaluated string.
🔧 Fix: Removed `eval()` and refactored the logic to check unset items directly against `st.session_state.get(key)`.
✅ Verification: Confirmed syntax is correct via `python3 -m py_compile script.py` and visual inspection of dictionary mapping.

---
*PR created automatically by Jules for task [215481038610597140](https://jules.google.com/task/215481038610597140) started by @haseeb-heaven*