### PR TITLE
🎨 Palette: Add loading spinners to long-running operations

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-21 - Adding Immediate Feedback to Streamlit Actions
+**Learning:** In Streamlit applications, long-running operations (like API calls) freeze the application without giving visual feedback, leading to a poor experience. Complex conditional branches make it difficult to wrap large sections in `st.spinner`.
+**Action:** Apply `with st.spinner("..."):` selectively to targeted execution blocks to keep micro-UX changes under 50 lines while providing immediate visual feedback to the user.

--- a/script.py
+++ b/script.py
@@ -383,7 +383,8 @@ def main():
                     logger.info("Setting Stderr from input to Debug instructions.")
                     
                 logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
+                with st.spinner("Debugging code..."):
+                    st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
         # Debug Code button in the fourth column
         with convert_code_col:
@@ -399,7 +400,8 @@ def main():
                     ai_llm_selected = st.session_state.openai_langchain
                     
                 logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
+                with st.spinner("Converting code..."):
+                    st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
         # Run Code button in the fourth column
@@ -410,7 +412,8 @@ def main():
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
     
                 if privacy_accepted:
-                    st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
+                    with st.spinner("Executing code..."):
+                        st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
                 else:
                     st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
                     logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")


### PR DESCRIPTION
💡 What: Wrapped the execution blocks of "Debug", "Convert", and "Execute" operations in `st.spinner()` blocks.
🎯 Why: Long-running operations, such as API calls or code compilation, previously froze the application UI without providing any immediate visual feedback to the user, leading to a confusing and poor experience.
📸 Before/After: Before, clicking a button caused the UI to freeze silently. After, a loading spinner immediately appears with text explaining what action is occurring (e.g., "Debugging code...").
♿ Accessibility: Provides necessary visual feedback to users that their action was registered and processing is underway, preventing duplicate clicks and reducing confusion.

---
*PR created automatically by Jules for task [9538598030377063600](https://jules.google.com/task/9538598030377063600) started by @haseeb-heaven*