### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Upload Handler

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-23 - [Path Traversal in Upload Handler]
+**Vulnerability:** User-provided filename was used directly in `os.path.join(temp_dir, uploadedfile.name)` without sanitization, allowing path traversal (e.g., `../../`) outside the intended directory.
+**Learning:** Filenames from untrusted sources (like uploaded files) must never be trusted. They can contain directory traversal sequences that trick the server into writing files to unintended locations, potentially leading to arbitrary code execution or overwriting critical system files.
+**Prevention:** Always sanitize user-provided filenames using `os.path.basename(filename)` before using them in file system operations to ensure the file is saved exactly in the intended directory.

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -412,7 +412,9 @@ class GeneralUtils:
             os.makedirs(temp_dir, exist_ok=True)
             
             logger.info(f"Saving uploaded file to {temp_dir}")
-            file_path = os.path.join(temp_dir, uploadedfile.name)
+            # Sanitize filename to prevent path traversal vulnerability
+            safe_filename = os.path.basename(uploadedfile.name)
+            file_path = os.path.join(temp_dir, safe_filename)
             with open(file_path, "wb") as f:
                 f.write(uploadedfile.getbuffer())
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-provided filename was used directly in `os.path.join` without sanitization, allowing path traversal (e.g., `../../`) outside the intended directory.
🎯 Impact: Attackers could overwrite critical system files or upload malicious files to unintended directories, potentially leading to arbitrary code execution or system compromise.
🔧 Fix: Sanitized user-provided filenames using `os.path.basename()` before passing them to file system operations, preventing directory traversal sequences. Added a Sentinel Journal entry.
✅ Verification: Ran `python3 -m py_compile libs/general_utils.py` to ensure syntax validity. Confirmed the journal entry was created and formatted correctly.

---
*PR created automatically by Jules for task [13393538340128142420](https://jules.google.com/task/13393538340128142420) started by @haseeb-heaven*