### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval() arbitrary code execution risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-24 - Remove eval() for Session State Evaluation
+**Vulnerability:** The application used `eval()` to dynamically evaluate string literals (e.g., `'st.session_state.project'`) from dictionary keys.
+**Learning:** While the strings were hardcoded, using `eval()` to check state is a security anti-pattern. If any dynamically generated or user-controlled string entered this flow, it would lead to Critical Arbitrary Code Execution.
+**Prevention:** Never use `eval()` to dynamically evaluate code strings or check dictionary values. Instead, use safe retrieval methods like `st.session_state.get(key)`.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application used `eval()` to dynamically evaluate string literals (e.g., `'st.session_state.project'`) from dictionary keys during Vertex AI configuration validation.
🎯 Impact: While the current strings were hardcoded, checking application state via `eval()` is a critical security anti-pattern. If this pattern were extended and user-controlled input entered this flow, it would lead to Critical Arbitrary Code Execution on the host system.
🔧 Fix: Removed the use of `eval()` entirely. Updated the dictionary keys to map directly to the `st.session_state` keys and replaced the `eval(var)` check with a safe and direct `st.session_state.get(key)` check.
✅ Verification: Ran `python3 -m py_compile script.py` successfully. Reviewed the logic to ensure the intended validation still correctly flags unset session state variables for Vertex AI.

---
*PR created automatically by Jules for task [5629131084011988405](https://jules.google.com/task/5629131084011988405) started by @haseeb-heaven*