### PR TITLE
🎨 Palette: Add visual feedback for long-running tasks

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-24 - Adding Immediate Visual Feedback
+**Learning:** In Streamlit applications, wrapping long-running operations (like AI generation or external API calls) in `with st.spinner("..."):` provides clear, immediate visual feedback to the user, enhancing perceived performance and preventing confusion. Applying this micro-UX change directly to the execution block keeps the modification small (< 50 lines) without needing to wrap large conditional branches.
+**Action:** Always add loading spinners to long-running tasks in Streamlit apps for a smoother and more responsive user experience.

--- a/script.py
+++ b/script.py
@@ -383,7 +383,8 @@ def main():
                     logger.info("Setting Stderr from input to Debug instructions.")
                     
                 logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
+                with st.spinner("Debugging code..."):
+                    st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
         # Debug Code button in the fourth column
         with convert_code_col:
@@ -399,7 +400,8 @@ def main():
                     ai_llm_selected = st.session_state.openai_langchain
                     
                 logger.info(f"Converting code with instructions: {st.session_state.code_fix_instructions}")
-                st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
+                with st.spinner("Converting code..."):
+                    st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
         # Run Code button in the fourth column
@@ -410,7 +412,8 @@ def main():
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
     
                 if privacy_accepted:
-                    st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
+                    with st.spinner("Executing code..."):
+                        st.session_state.output = st.session_state.general_utils.execute_code(st.session_state.compiler_mode)
                 else:
                     st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
                     logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")


### PR DESCRIPTION
💡 What: Added `st.spinner` to long-running API operations in Streamlit.
🎯 Why: Without visual feedback, users might think the app has frozen during slow external API requests (debugging, converting, or executing code). This provides immediate visual reassurance.
📸 Before/After: No spinner -> `st.spinner` ("Debugging code...", "Converting code...", "Executing code...").
♿ Accessibility: Enhances perceived performance and cognitive accessibility by clearly indicating that a background process is ongoing.

---
*PR created automatically by Jules for task [15157311177879254804](https://jules.google.com/task/15157311177879254804) started by @haseeb-heaven*