### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval() arbitrary code execution vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-25 - Remove Dangerous eval() Execution
+**Vulnerability:** Arbitrary code execution vulnerability via the use of `eval()` to check if Streamlit session state variables were set in `script.py`.
+**Learning:** Using `eval()` with any dynamically-referenced string is a major security anti-pattern as it executes arbitrary code.
+**Prevention:** Use safer dictionary access methods like `st.session_state.get(key)` instead of evaluating code strings.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
-                        # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        # Use a list comprehension to filter out the unset items safely
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Arbitrary code execution via the use of `eval()` to check Streamlit session state variables in `script.py`.
🎯 Impact: An attacker could potentially inject and execute arbitrary Python code if they could manipulate the keys being evaluated (though currently mitigated by hardcoded keys, it's a severe anti-pattern).
🔧 Fix: Replaced the `eval(var)` check with a safe dictionary access pattern `st.session_state.get(key)`. Updated the dictionary to use simple keys instead of fully qualified string representations of variables.
✅ Verification: Ran `python3 -m py_compile script.py` to ensure syntax is correct. Added a learning journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14982480334084730148](https://jules.google.com/task/14982480334084730148) started by @haseeb-heaven*