### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix eval() vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-27 - [CRITICAL] Removed eval() Anti-Pattern from Session State Checks
+**Vulnerability:** The codebase was using `eval()` to dynamically evaluate strings for checking if session state variables were set (e.g., `eval("st.session_state.project")`). This is a dangerous anti-pattern that can lead to Arbitrary Code Execution (RCE) if user input is ever incorporated into the evaluated string.
+**Learning:** Found a specific security vulnerability pattern in this codebase where `eval()` was used for dictionary value extraction and state checking instead of safer property accessor methods.
+**Prevention:** Never use `eval()` to dynamically evaluate code strings or check dictionary values. Use safer alternatives like `dict.get(key)` or `st.session_state.get(key)` to retrieve values securely without risk of code execution.

--- a/script.py
+++ b/script.py
@@ -160,15 +160,15 @@ def main():
                             st.toast(f"Error loading Vertex AI: {str(exception)}", icon="❌")
                             logger.error(f"Error loading Vertex AI: {str(exception)}")
                     else:
-                        # Define a dictionary mapping variable names
+                        # Define a dictionary mapping variable names (SECURITY: avoid eval() on strings)
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
-                        # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        # Use a list comprehension to filter out the unset items securely via st.session_state.get()
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The codebase was using `eval()` to dynamically evaluate strings (`'st.session_state.project'`, etc.) when checking if required session state variables were set.
🎯 Impact: Using `eval()` is a highly dangerous security anti-pattern. If user input ever became incorporated into the string being evaluated, it could lead to Remote Code Execution (RCE).
🔧 Fix: Removed `eval()` entirely. Modified the `items` dictionary to map bare string keys (e.g., `'project'`) and replaced the list comprehension to use Streamlit's safer accessor: `st.session_state.get(key)`. This safely checks for the property's existence without risking arbitrary execution.
✅ Verification: Ran `python3 -m py_compile script.py` successfully and verified code change formatting. Added critical learning note to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6040376497490741499](https://jules.google.com/task/6040376497490741499) started by @haseeb-heaven*