### PR TITLE
🎨 Palette: Add helpful tooltips to action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-28 - Added helpful tooltips to form action buttons
+**Learning:** Adding the `help` parameter to Streamlit `st.form_submit_button` provides accessible tooltips to icon-only or generic-action buttons without cluttering the UI, acting as a quick micro-UX win for better discoverability.
+**Action:** Use Streamlit's native `help` parameter on interactive elements to explain actions, especially when space is constrained or functionality isn't immediately obvious.

--- a/script.py
+++ b/script.py
@@ -298,7 +298,7 @@ def main():
 
         # Save Code button in the second column
         with save_code_col:
-            download_code_submitted = st.form_submit_button("Download")
+            download_code_submitted = st.form_submit_button("Download", help="Download the generated code")
             if download_code_submitted:
                 file_format = "text/plain"
                 st.session_state.download_link = st.session_state.general_utils.generate_download_link(st.session_state.generated_code, code_file,file_format,True)
@@ -306,7 +306,7 @@ def main():
         # Generate Code button in the third column
         with generate_code_col:
             button_label = "Generate" if st.session_state["vertexai"]["model_name"] == "code-bison" else "Complete"
-            generate_submitted = st.form_submit_button(button_label)
+            generate_submitted = st.form_submit_button(button_label, help="Generate or complete code based on prompt")
             
             if generate_submitted:
                 if st.session_state.ai_option == "Open AI":
@@ -363,7 +363,7 @@ def main():
 
         # Debug Code button in the fourth column
         with debug_code_col:
-            debug_submitted = st.form_submit_button("Debug")
+            debug_submitted = st.form_submit_button("Debug", help="Debug code based on instructions")
             ai_llm_selected = None
             if debug_submitted:
                 # checking for the selected AI option
@@ -387,7 +387,7 @@ def main():
 
         # Debug Code button in the fourth column
         with convert_code_col:
-            convert_submitted = st.form_submit_button("Convert")
+            convert_submitted = st.form_submit_button("Convert", help="Convert code to the selected language")
             ai_llm_selected = None
             if convert_submitted:
                 # checking for the selected AI option
@@ -404,7 +404,7 @@ def main():
 
         # Run Code button in the fourth column
         with run_code_col:
-            execute_submitted = st.form_submit_button("Execute")
+            execute_submitted = st.form_submit_button("Execute", help="Run the code and see output")
             if execute_submitted:          
                 # Execute the code.
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
@@ -417,7 +417,7 @@ def main():
 
         # Example Code button in the fifth column
         with example_code_col:
-            example_submitted = st.form_submit_button("Example")
+            example_submitted = st.form_submit_button("Example", help="Load a random example prompt")
             if example_submitted:
                 task_name, task_input, task_output = st.session_state.tasks_parser.get_random_task()
                 st.session_state.code_prompt = "Task = '" + str(task_name) + "'\nInput = '" + str(task_input) + "'\nOutput = '" + str(task_output) + "'"


### PR DESCRIPTION
Added `help` parameter to Streamlit `st.form_submit_button` calls in `script.py` for "Download", "Generate", "Debug", "Convert", "Execute", and "Example" buttons. This provides accessible tooltips explaining the function of each button, improving discoverability and overall user experience without cluttering the interface.

Also added a corresponding UX journal entry in `.jules/palette.md`.

---
*PR created automatically by Jules for task [12003895957472097498](https://jules.google.com/task/12003895957472097498) started by @haseeb-heaven*