### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution vulnerability (eval)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-04 - Insecure eval() usage for dictionary values
+**Vulnerability:** The application used eval() to dynamically check state variables inside a list comprehension, which is a critical security anti-pattern.
+**Learning:** Using eval() on code strings, even if seemingly controlled, introduces arbitrary code execution risks.
+**Prevention:** Use safer alternatives such as dict.get(key) or st.session_state.get(key) for dynamic state evaluation.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
This PR removes the unsafe `eval()` used in the Vertex AI settings block within `script.py`. The `eval()` function was dynamically evaluating `st.session_state` keys constructed as string variables, which is a known vulnerability risk for arbitrary code execution. It has been replaced with a secure dictionary lookup via `st.session_state.get()`. This is part of a security hardening effort (Sentinel).

---
*PR created automatically by Jules for task [16168328694022450618](https://jules.google.com/task/16168328694022450618) started by @haseeb-heaven*