### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in general_utils.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-07 - Path Traversal in File Upload
+**Vulnerability:** Unsanitized user-provided filename used in file system operations.
+**Learning:** Always sanitize user-provided filenames using `os.path.basename()` before using them in file system operations (like `os.path.join` or `open`) to prevent path traversal vulnerabilities.
+**Prevention:** Sanitize user input and follow the principle of least privilege.

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -412,7 +412,9 @@ class GeneralUtils:
             os.makedirs(temp_dir, exist_ok=True)
             
             logger.info(f"Saving uploaded file to {temp_dir}")
-            file_path = os.path.join(temp_dir, uploadedfile.name)
+            # Security fix: Sanitize filename to prevent path traversal
+            safe_filename = os.path.basename(uploadedfile.name)
+            file_path = os.path.join(temp_dir, safe_filename)
             with open(file_path, "wb") as f:
                 f.write(uploadedfile.getbuffer())
                 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Uploads

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsanitized user-provided filenames (`uploadedfile.name`) were being passed directly to `os.path.join()` during the temporary file upload process in `libs/general_utils.py`. 
🎯 **Impact:** An attacker could potentially upload files with names containing directory traversal payloads (e.g., `../../../etc/passwd`), leading to arbitrary file writes or sensitive data overwriting on the server.
🔧 **Fix:** Sanitized the incoming file name using `os.path.basename()` to strip any directory paths, ensuring only the raw file name is used in the local `os.path.join()` operation. Also recorded this critical learning in the `.jules/sentinel.md` journal.
✅ **Verification:** Verified syntax with `python3 -m py_compile libs/general_utils.py` and reviewed the correct format of `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [824003424404299590](https://jules.google.com/task/824003424404299590) started by @haseeb-heaven*