### PR TITLE
🎨 Palette: Add descriptive tooltips to form submit buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-11 - Adding Tooltips to Streamlit Form Submit Buttons
+**Learning:** Streamlit form submit buttons lack descriptive tooltips by default, which can obscure their precise function, especially for users relying on context. Adding a 'help' parameter provides a quick and accessible tooltip that enhances usability without cluttering the UI.
+**Action:** When creating 'st.form_submit_button' instances, always include a descriptive 'help' string to explain the button's action.

--- a/script.py
+++ b/script.py
@@ -298,7 +298,7 @@ def main():
 
         # Save Code button in the second column
         with save_code_col:
-            download_code_submitted = st.form_submit_button("Download")
+            download_code_submitted = st.form_submit_button("Download", help="Download the generated code as a text file")
             if download_code_submitted:
                 file_format = "text/plain"
                 st.session_state.download_link = st.session_state.general_utils.generate_download_link(st.session_state.generated_code, code_file,file_format,True)
@@ -306,7 +306,7 @@ def main():
         # Generate Code button in the third column
         with generate_code_col:
             button_label = "Generate" if st.session_state["vertexai"]["model_name"] == "code-bison" else "Complete"
-            generate_submitted = st.form_submit_button(button_label)
+            generate_submitted = st.form_submit_button(button_label, help="Generate or complete the code based on your prompt")
             
             if generate_submitted:
                 if st.session_state.ai_option == "Open AI":
@@ -363,7 +363,7 @@ def main():
 
         # Debug Code button in the fourth column
         with debug_code_col:
-            debug_submitted = st.form_submit_button("Debug")
+            debug_submitted = st.form_submit_button("Debug", help="Debug the code with the provided instructions")
             ai_llm_selected = None
             if debug_submitted:
                 # checking for the selected AI option
@@ -387,7 +387,7 @@ def main():
 
         # Debug Code button in the fourth column
         with convert_code_col:
-            convert_submitted = st.form_submit_button("Convert")
+            convert_submitted = st.form_submit_button("Convert", help="Convert the code to the selected target language")
             ai_llm_selected = None
             if convert_submitted:
                 # checking for the selected AI option
@@ -404,7 +404,7 @@ def main():
 
         # Run Code button in the fourth column
         with run_code_col:
-            execute_submitted = st.form_submit_button("Execute")
+            execute_submitted = st.form_submit_button("Execute", help="Execute the code using the selected compiler")
             if execute_submitted:          
                 # Execute the code.
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
@@ -417,7 +417,7 @@ def main():
 
         # Example Code button in the fifth column
         with example_code_col:
-            example_submitted = st.form_submit_button("Example")
+            example_submitted = st.form_submit_button("Example", help="Load a random example prompt")
             if example_submitted:
                 task_name, task_input, task_output = st.session_state.tasks_parser.get_random_task()
                 st.session_state.code_prompt = "Task = '" + str(task_name) + "'\nInput = '" + str(task_input) + "'\nOutput = '" + str(task_output) + "'"


### PR DESCRIPTION
💡 **What:** Added descriptive `help` parameters to all `st.form_submit_button` instances in the main `script.py` interface (Download, Generate, Debug, Convert, Execute, Example).
🎯 **Why:** Streamlit form buttons lack native tooltips. Adding a `help` string provides users with context on hover, clarifying the button's action without visually cluttering the main interface.
♿ **Accessibility:** Enhances discoverability and provides better context for interactive elements.
📸 **Before/After:** Not applicable (micro-UX text enhancement).

Also recorded this learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [18346257440377814362](https://jules.google.com/task/18346257440377814362) started by @haseeb-heaven*