### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution vulnerability via eval()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-12 - [Fix eval() usage for Session State Checks]
+**Vulnerability:** The code used `eval(var)` to dynamically evaluate string representations of Streamlit session state variables (like `'st.session_state.project'`).
+**Learning:** Using `eval()` is a critical security risk as it can lead to arbitrary code execution if user inputs or dynamically generated strings are ever introduced into the evaluation target.
+**Prevention:** Always use safe dictionary access methods like `st.session_state.get(key)` to retrieve values dynamically, avoiding code evaluation functions entirely.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
This PR addresses a critical security vulnerability found in `script.py`. The code was using the `eval()` function to dynamically evaluate string representations of Streamlit session state variables. Using `eval()` poses a severe risk of arbitrary code execution.

The fix replaces `eval(var)` with `st.session_state.get(var)`, ensuring safe and direct retrieval of values from the dictionary-like session state. The keys in the `items` mapping have also been updated to align with the direct dictionary access pattern.

Additionally, a Sentinel journal entry has been created to document this critical security learning and prevention strategy.

---
*PR created automatically by Jules for task [13612975533923869000](https://jules.google.com/task/13612975533923869000) started by @haseeb-heaven*