### PR TITLE
🎨 Palette: Add informative tooltips to form action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-13 - Added helpful tooltips to form action buttons
+**Learning:** In Streamlit, adding `help` parameters to `st.form_submit_button` provides native, accessible tooltips on hover. This is an effective way to clarify the specific behavior of action buttons without cluttering the UI with additional text.
+**Action:** Always consider adding `help` text to main action buttons in Streamlit applications, especially when the button label alone might be slightly ambiguous (e.g., "Example" vs. "Load random example prompt").

--- a/script.py
+++ b/script.py
@@ -298,7 +298,7 @@ def main():
 
         # Save Code button in the second column
         with save_code_col:
-            download_code_submitted = st.form_submit_button("Download")
+            download_code_submitted = st.form_submit_button("Download", help="Download the generated code as a text file")
             if download_code_submitted:
                 file_format = "text/plain"
                 st.session_state.download_link = st.session_state.general_utils.generate_download_link(st.session_state.generated_code, code_file,file_format,True)
@@ -306,7 +306,7 @@ def main():
         # Generate Code button in the third column
         with generate_code_col:
             button_label = "Generate" if st.session_state["vertexai"]["model_name"] == "code-bison" else "Complete"
-            generate_submitted = st.form_submit_button(button_label)
+            generate_submitted = st.form_submit_button(button_label, help="Generate or complete code based on the prompt")
             
             if generate_submitted:
                 if st.session_state.ai_option == "Open AI":
@@ -363,7 +363,7 @@ def main():
 
         # Debug Code button in the fourth column
         with debug_code_col:
-            debug_submitted = st.form_submit_button("Debug")
+            debug_submitted = st.form_submit_button("Debug", help="Debug the generated code using the provided instructions")
             ai_llm_selected = None
             if debug_submitted:
                 # checking for the selected AI option
@@ -385,9 +385,9 @@ def main():
                 logger.info(f"Fixing code with instructions: {st.session_state.code_fix_instructions}")
                 st.session_state.generated_code = ai_llm_selected.fix_generated_code(st.session_state.generated_code, st.session_state.code_language,st.session_state.code_fix_instructions)
 
-        # Debug Code button in the fourth column
+        # Convert Code button in the fifth column
         with convert_code_col:
-            convert_submitted = st.form_submit_button("Convert")
+            convert_submitted = st.form_submit_button("Convert", help="Convert the generated code to another language")
             ai_llm_selected = None
             if convert_submitted:
                 # checking for the selected AI option
@@ -402,9 +402,9 @@ def main():
                 st.session_state.generated_code = ai_llm_selected.convert_generated_code(st.session_state.generated_code, st.session_state.code_language)
 
 
-        # Run Code button in the fourth column
+        # Run Code button in the sixth column
         with run_code_col:
-            execute_submitted = st.form_submit_button("Execute")
+            execute_submitted = st.form_submit_button("Execute", help="Run the generated code and view the output")
             if execute_submitted:          
                 # Execute the code.
                 privacy_accepted = st.session_state.get(f'compiler_{st.session_state.compiler_mode.lower()}_privacy_accepted', False)
@@ -415,9 +415,9 @@ def main():
                     st.toast(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.", icon="❌")
                     logger.error(f"You didn't accept the privacy policy for {st.session_state.compiler_mode} compiler.")
 
-        # Example Code button in the fifth column
+        # Example Code button in the seventh column
         with example_code_col:
-            example_submitted = st.form_submit_button("Example")
+            example_submitted = st.form_submit_button("Example", help="Load a random example prompt and inputs")
             if example_submitted:
                 task_name, task_input, task_output = st.session_state.tasks_parser.get_random_task()
                 st.session_state.code_prompt = "Task = '" + str(task_name) + "'\nInput = '" + str(task_input) + "'\nOutput = '" + str(task_output) + "'"


### PR DESCRIPTION
Added informative `help` tooltips to the main action buttons (`st.form_submit_button`) to improve micro-UX and accessibility. Corrected the comments documenting the column numbers.

---
*PR created automatically by Jules for task [18315025293517848791](https://jules.google.com/task/18315025293517848791) started by @haseeb-heaven*