### PR TITLE
🛡️ Sentinel: [CRITICAL] Replace eval() with safer state lookup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-08-14 - Arbitrary Code Execution via eval()
+
+**Vulnerability:** The application uses `eval()` to evaluate variable names dynamically constructed as strings when checking unset configuration items in `script.py`.
+**Learning:** Using `eval()` to evaluate strings is extremely dangerous and can lead to arbitrary code execution, especially if any part of the evaluated string ever becomes user-controllable.
+**Prevention:** Avoid `eval()` completely. Instead of building strings like 'st.session_state.project' and evaluating them, check the state keys directly using safe dictionary access methods, such as `st.session_state.get('project')`.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for var, name in items.items() if not st.session_state.get(var)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Replace eval() with safer state lookup

🚨 Severity: CRITICAL
💡 Vulnerability: The application used eval() to dynamically interpret string properties related to validating Vertex AI configurations.
🎯 Impact: This could allow arbitrary code execution if the parameters were ever supplied or influenced by unverified user input or manipulation.
🔧 Fix: Removed eval(). Refactored dictionary keys and updated list comprehension to use the safer st.session_state.get() lookup to verify if states are unset.
✅ Verification: Tested via python3 -m py_compile to ensure no syntax regressions were introduced.

---
*PR created automatically by Jules for task [14011271794263864578](https://jules.google.com/task/14011271794263864578) started by @haseeb-heaven*