### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-16 - [Path Traversal in File Upload]
+**Vulnerability:** Path traversal risk due to unsanitized `uploadedfile.name` in `os.path.join` within `libs/general_utils.py`.
+**Learning:** User-provided file names can contain directory traversal sequences (e.g., `../`) which can allow files to be saved outside the intended directory.
+**Prevention:** Always sanitize user-provided filenames using `os.path.basename()` before using them in file system operations.

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -412,7 +412,7 @@ class GeneralUtils:
             os.makedirs(temp_dir, exist_ok=True)
             
             logger.info(f"Saving uploaded file to {temp_dir}")
-            file_path = os.path.join(temp_dir, uploadedfile.name)
+            file_path = os.path.join(temp_dir, os.path.basename(uploadedfile.name))
             with open(file_path, "wb") as f:
                 f.write(uploadedfile.getbuffer())
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL\n💡 Vulnerability: Path traversal risk due to unsanitized `uploadedfile.name` in `os.path.join` within `libs/general_utils.py`. User-provided file names can contain directory traversal sequences (e.g., `../`) which can allow files to be saved outside the intended directory.\n🎯 Impact: An attacker could potentially upload files to arbitrary directories on the server filesystem, potentially overwriting critical system files or injecting malicious executable files.\n🔧 Fix: Sanitized the user-provided filename using `os.path.basename()` before passing it to `os.path.join()`, ensuring the file is saved strictly within the intended temporary directory.\n✅ Verification: The code compiles successfully. Verified manually that `os.path.basename()` effectively strips path traversal characters from filenames.

---
*PR created automatically by Jules for task [8745635655120356351](https://jules.google.com/task/8745635655120356351) started by @haseeb-heaven*