### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace os.system with subprocess.run

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-19 - Command Injection Vulnerability
+**Vulnerability:** Use of `os.system` with direct shell commands, potentially vulnerable to injection if input were ever parameterized or manipulated.
+**Learning:** Python's `os.system` is inherently risky when calling shell commands. It relies on the shell to parse the command string, which can lead to command injection if external input is introduced.
+**Prevention:** Always use `subprocess.run` with a list of arguments and `check=True` (or equivalent safe defaults) instead of `os.system`. This avoids the shell entirely and passes arguments directly to the executable, eliminating the risk of shell injection.

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import os
+import subprocess
 from streamlit_ace import st_ace
 from libs.logger import logger
 
@@ -203,9 +204,9 @@ def display_support():
 def upgrade_pip_packages():
     try:
         # upgrade pip
-        os.system("python -m pip install --upgrade pip")
+        subprocess.run(["python", "-m", "pip", "install", "--upgrade", "pip"], check=True)
         # upgrade pip packages
-        os.system("pip install -r requirements.txt --upgrade")
+        subprocess.run(["pip", "install", "-r", "requirements.txt", "--upgrade"], check=True)
     except Exception as e:
         print(f"Error upgrading pip packages: {e}")
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `upgrade_pip_packages` function in `libs/utils.py` used `os.system` with hardcoded strings to execute shell commands. While not immediately exploitable with user input in its current state, `os.system` is universally flagged as a security risk because it invokes a shell and is vulnerable to command injection if arguments are ever parameterized. Additionally, `os.system` does not raise exceptions on command failure, making the `try/except` block ineffective.
🎯 Impact: If arguments were ever introduced dynamically, an attacker could execute arbitrary shell commands on the server. Furthermore, failed package installations were silently ignored because `os.system` does not raise exceptions.
🔧 Fix: Replaced `os.system` with `subprocess.run` passing arguments as a list and using `check=True`. This entirely avoids invoking the shell, preventing any future risk of command injection, and properly raises a `CalledProcessError` if the command fails, allowing the `try/except` block to correctly catch and report errors. Added an entry to the `.jules/sentinel.md` journal.
✅ Verification: Ran `python3 -m py_compile libs/utils.py` to ensure syntax is correct. Checked that the changes are isolated to replacing `os.system` with the safer alternative.

---
*PR created automatically by Jules for task [16770307918619061751](https://jules.google.com/task/16770307918619061751) started by @haseeb-heaven*