### PR TITLE
🎨 Palette: Add help tooltip to Generate button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-19 - Adding help tooltips to Streamlit components
+**Learning:** Adding the `help` parameter to Streamlit UI components like `st.form_submit_button` provides a native, accessible tooltip (SVG icon) that enhances discoverability without cluttering the main interface.
+**Action:** Consistently utilize the `help` parameter for primary action buttons within forms to guide users on expected behavior, especially when button labels are concise.

--- a/script.py
+++ b/script.py
@@ -306,7 +306,7 @@ def main():
         # Generate Code button in the third column
         with generate_code_col:
             button_label = "Generate" if st.session_state["vertexai"]["model_name"] == "code-bison" else "Complete"
-            generate_submitted = st.form_submit_button(button_label)
+            generate_submitted = st.form_submit_button(button_label, help="Click to generate or complete code based on your prompt")
             
             if generate_submitted:
                 if st.session_state.ai_option == "Open AI":


### PR DESCRIPTION
Added a helpful tooltip to the Generate button to explain its functionality to the user, improving UX and discoverability.

---
*PR created automatically by Jules for task [4157653699438224598](https://jules.google.com/task/4157653699438224598) started by @haseeb-heaven*