### PR TITLE
🛡️ Sentinel: [HIGH] Fix eval() arbitrary code execution risk

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-21 - [eval() Arbitrary Code Execution Risk in Streamlit]
+**Vulnerability:** The use of `eval()` to check Streamlit session state variables (e.g. `eval('st.session_state.project')`).
+**Learning:** Using `eval()` poses a significant arbitrary code execution vulnerability risk if the strings passed to it are ever influenced by user input. In this case, while checking internal state variables, relying on `eval()` is a dangerous pattern.
+**Prevention:** Always use safe dictionary access methods like `st.session_state.get(key)` to check for variables dynamically, and explicitly avoid `eval()` for state inspection.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Used `eval()` to evaluate dynamic inputs, allowing potential arbitrary code execution if inputs were ever exposed to user.
🎯 Impact: Prevents system compromise by untrusted inputs in the Vertex AI error handler logic.
🔧 Fix: Replaced `eval()` with `st.session_state.get(key)`.
✅ Verification: Ensure application runs smoothly by using `python3 -m py_compile` and application functions as before.

---
*PR created automatically by Jules for task [15826748335791943270](https://jules.google.com/task/15826748335791943270) started by @haseeb-heaven*