### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file upload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-22 - [Path Traversal in File Upload]
+**Vulnerability:** [The `save_uploaded_file_temp` method directly used the user-provided `uploadedfile.name` in `os.path.join` without sanitization, creating a path traversal vulnerability.]
+**Learning:** [User-supplied filenames can contain directory traversal characters like `../`, allowing attackers to write files outside the intended temporary directory, potentially overwriting critical system files.]
+**Prevention:** [Always sanitize user-provided filenames using functions like `os.path.basename()` before using them in file system operations like `os.path.join` or `open`.]

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -412,7 +412,9 @@ class GeneralUtils:
             os.makedirs(temp_dir, exist_ok=True)
             
             logger.info(f"Saving uploaded file to {temp_dir}")
-            file_path = os.path.join(temp_dir, uploadedfile.name)
+            # Sanitize the filename to prevent path traversal
+            safe_filename = os.path.basename(uploadedfile.name)
+            file_path = os.path.join(temp_dir, safe_filename)
             with open(file_path, "wb") as f:
                 f.write(uploadedfile.getbuffer())
                 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `save_uploaded_file_temp` method in `libs/general_utils.py` directly used the user-provided `uploadedfile.name` in `os.path.join` without sanitization, creating a path traversal vulnerability.
🎯 Impact: Attackers could supply filenames containing directory traversal characters (e.g., `../../../etc/passwd`), allowing them to write files outside the intended `tempDir`, potentially overwriting critical system files or executing arbitrary code.
🔧 Fix: Sanitized the user-provided filename using `os.path.basename()` before passing it to `os.path.join()`.
✅ Verification: Ran `python3 -m py_compile script.py libs/*.py` to ensure syntax integrity. Evaluated the fix logically to confirm path traversal payloads are now properly stripped to just the filename.

---
*PR created automatically by Jules for task [10439809140845512023](https://jules.google.com/task/10439809140845512023) started by @haseeb-heaven*