### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary code execution via eval()

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2026-08-24 - Prevent Arbitrary Code Execution using eval() in session state checks
+
+**Vulnerability:** The application uses `eval()` to dynamically check if values like `st.session_state.project` exist. This is a critical security risk because it allows for arbitrary code execution if an attacker can control the string being evaluated.
+**Learning:** Checking state values should never use `eval()`. Instead of passing string representations of variable access, we can safely access variables directly or safely use dictionary lookups using `.get()`.
+**Prevention:** Always use safe dictionary lookup methods like `dict.get(key)` or direct property access instead of `eval()` to prevent command injection and arbitrary code execution vulnerabilities.

--- a/script.py
+++ b/script.py
@@ -162,13 +162,13 @@ def main():
                     else:
                         # Define a dictionary mapping variable names
                         items = {
-                            'st.session_state.project': 'Project name',
-                            'st.session_state.region': 'App region',
-                            'st.session_state.uploaded_file': 'Credentials file'
+                            'project': 'Project name',
+                            'region': 'App region',
+                            'uploaded_file': 'Credentials file'
                         }
 
                         # Use a list comprehension to filter out the unset items
-                        unset_items = [name for var, name in items.items() if not eval(var)]
+                        unset_items = [name for key, name in items.items() if not st.session_state.get(key)]
 
                         # Construct the error message
                         error_message = "Please select all settings for Vertex AI".join([f"{item} is not selected." for item in unset_items])


### PR DESCRIPTION
Replaced `eval()` with safe dictionary `.get()` method to prevent potential command injection and arbitrary code execution when verifying Vertex AI settings in Streamlit session state. Also added critical learnings to `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [4870627312700966881](https://jules.google.com/task/4870627312700966881) started by @haseeb-heaven*