### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Uploaded Files

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-25 - [Path Traversal in Uploaded Files]
+**Vulnerability:** User-provided filename in `save_uploaded_file_temp` was directly joined with the temporary directory path, allowing for path traversal vulnerabilities.
+**Learning:** Malicious actors could craft a POST request with a full path like `../../../etc/passwd` to write files outside the intended directory.
+**Prevention:** Always sanitize user-provided filenames using `os.path.basename()` before using them in file system operations.

--- a/libs/general_utils.py
+++ b/libs/general_utils.py
@@ -412,7 +412,7 @@ class GeneralUtils:
             os.makedirs(temp_dir, exist_ok=True)
             
             logger.info(f"Saving uploaded file to {temp_dir}")
-            file_path = os.path.join(temp_dir, uploadedfile.name)
+            file_path = os.path.join(temp_dir, os.path.basename(uploadedfile.name))
             with open(file_path, "wb") as f:
                 f.write(uploadedfile.getbuffer())
                 


### PR DESCRIPTION
# 🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Uploaded Files

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `save_uploaded_file_temp` function directly concatenated user-provided filenames with the temporary directory path, allowing for path traversal vulnerabilities.
🎯 **Impact:** Malicious actors could craft a POST request with a full path like `../../../etc/passwd` to write files outside the intended directory.
🔧 **Fix:** Sanitized user-provided filenames using `os.path.basename()` before using them in file system operations.
✅ **Verification:** Verified by checking that `os.path.basename` is applied to the uploaded file name. Also ensured that the python code compiles correctly.

---
*PR created automatically by Jules for task [11832679230003972062](https://jules.google.com/task/11832679230003972062) started by @haseeb-heaven*